### PR TITLE
feat(view-switcher): make toolbar draggable

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -229,15 +229,6 @@ iframe {
   border-bottom: 1px solid #6a6e73;
 }
 
-/* When the view switcher is active, reserve space so tabs don't go under it */
-.sr-view-split .app-split-right__top-bar {
-  padding-right: 300px;
-}
-@media (max-width: 900px) {
-  .sr-view-split .app-split-right__top-bar {
-    padding-right: 140px;
-  }
-}
 .app-split-right__tabs {
   height: 100%;
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -616,8 +616,16 @@ export default function () {
       )}
       <div className={`app-wrapper${viewMode === 'instructions' ? ' sr-view-instructions' : viewMode === 'split' ? ' sr-view-split' : viewMode === 'tabs' ? ' sr-view-tabs' : ''}`}>
         <Split
-          sizes={moduleTabs.length > 0 ? [leftPaneDefault, 100 - leftPaneDefault] : [100]}
-          minSize={100}
+          sizes={
+            moduleTabs.length > 0
+              ? viewMode === 'instructions'
+                ? [100, 0]
+                : viewMode === 'tabs'
+                ? [0, 100]
+                : [leftPaneDefault, 100 - leftPaneDefault]
+              : [100]
+          }
+          minSize={viewMode === 'instructions' || viewMode === 'tabs' ? 0 : 100}
           gutterSize={1}
           direction="horizontal"
           cursor="col-resize"

--- a/src/view-switcher.css
+++ b/src/view-switcher.css
@@ -1,8 +1,8 @@
 /*
  * view-switcher.css
  *
- * Styles for the draggable floating toolbar that lets users switch between
- * Instructions / Split / Tabs layout modes.
+ * Styles for the edge-snapping floating toolbar that lets users switch
+ * between Instructions / Split / Tabs layout modes.
  *
  * Positioning strategy
  * --------------------
@@ -11,11 +11,12 @@
  * intentional — transforms are GPU-composited and do not trigger layout
  * recalculation on every frame the way left/top changes would.
  *
- * Drag lifecycle (set by ViewSwitcher component)
- * -----------------------------------------------
- *   pointerdown on .sr-drag-handle → body gets .sr-dragging (grabbing cursor)
+ * Drag + snap lifecycle
+ * ---------------------
+ *   pointerdown on .sr-drag-handle → body gets .sr-dragging, sr-snapping removed
  *   pointermove → transform updated directly on the DOM (no React re-render)
- *   pointerup   → .sr-dragging removed, React state and localStorage updated
+ *   pointerup   → nearest anchor found, sr-snapping added, transform animates
+ *   transitionend → sr-snapping removed, ready for next drag
  *
  * Mode overrides
  * --------------
@@ -39,6 +40,18 @@
    */
   will-change: transform;
   touch-action: none;
+}
+
+/* ── Snap animation ─────────────────────────────────────────────────────── */
+
+/*
+ * Added by JS on pointer-up, removed on transitionend. Enables a smooth
+ * ease-out from the free-drag position to the nearest anchor point.
+ * The class is also removed on the next pointer-down so a quick re-grab
+ * cancels the animation and the toolbar responds immediately.
+ */
+.sr-toolbar-wrapper.sr-snapping {
+  transition: transform 0.25s ease-out;
 }
 
 /* ── Toolbar pill ────────────────────────────────────────────────────────── */

--- a/src/view-switcher.css
+++ b/src/view-switcher.css
@@ -1,17 +1,47 @@
-/* View Switcher — draggable floating toolbar for switching between
-   Instructions / Split / Tabs modes.
-   Default position: bottom-center. User can drag to reposition;
-   position is persisted to localStorage under 'sr-toolbar-pos'. */
+/*
+ * view-switcher.css
+ *
+ * Styles for the draggable floating toolbar that lets users switch between
+ * Instructions / Split / Tabs layout modes.
+ *
+ * Positioning strategy
+ * --------------------
+ * The wrapper is fixed at (left:0, top:0) in the viewport. Actual position
+ * is applied via CSS transform: translate(x, y) from JavaScript. This is
+ * intentional — transforms are GPU-composited and do not trigger layout
+ * recalculation on every frame the way left/top changes would.
+ *
+ * Drag lifecycle (set by ViewSwitcher component)
+ * -----------------------------------------------
+ *   pointerdown on .sr-drag-handle → body gets .sr-dragging (grabbing cursor)
+ *   pointermove → transform updated directly on the DOM (no React re-render)
+ *   pointerup   → .sr-dragging removed, React state and localStorage updated
+ *
+ * Mode overrides
+ * --------------
+ * Switching modes adds .sr-view-{mode} to .app-wrapper. CSS then shows/hides
+ * split panes without touching Split.js inline styles (which would fight back).
+ */
+
+/* ── Toolbar wrapper ─────────────────────────────────────────────────────── */
 
 .sr-toolbar-wrapper {
   position: fixed;
   left: 0;
   top: 0;
   z-index: 100;
-  /* Position applied via transform: translate(x, y) — GPU-composited, no layout reflow */
+  /*
+   * transform: translate(x, y) is written by JavaScript to position the toolbar.
+   * will-change tells the browser to promote this element to its own compositor
+   * layer up front, so transform updates don't cause repaints of other layers.
+   * touch-action: none lets our pointer handlers work on touch screens without
+   * the browser trying to scroll the page at the same time.
+   */
   will-change: transform;
   touch-action: none;
 }
+
+/* ── Toolbar pill ────────────────────────────────────────────────────────── */
 
 .sr-toolbar {
   display: flex;
@@ -24,10 +54,14 @@
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
-/* Drag handle — grip dots on the left of the toolbar */
+/* ── Drag handle ─────────────────────────────────────────────────────────── */
+
 .sr-drag-handle {
   display: flex;
   align-items: center;
+  justify-content: center;
+  /* Generous padding gives a larger hit target — easier to grab accurately */
+  min-width: 28px;
   padding: 6px 10px 6px 8px;
   cursor: grab;
   color: #555;
@@ -35,9 +69,6 @@
   margin-right: 2px;
   border-radius: 5px 0 0 5px;
   transition: color 0.15s;
-  /* Larger hit area so it's easier to grab */
-  min-width: 28px;
-  justify-content: center;
 }
 
 .sr-drag-handle:hover {
@@ -49,15 +80,27 @@
   width: 16px;
   height: 16px;
   flex-shrink: 0;
+  /* pointer-events: none prevents the SVG from intercepting pointer events
+     that should be handled by the parent .sr-drag-handle div */
   pointer-events: none;
 }
 
-/* Applied to body during drag to enforce grab cursor everywhere */
+/* ── Global drag state ───────────────────────────────────────────────────── */
+
+/*
+ * While dragging, body gets .sr-dragging so the grabbing cursor applies
+ * everywhere on the page — not just over the handle. Without this, moving
+ * the pointer quickly over other elements causes the cursor to flicker back
+ * to the default arrow cursor.
+ * user-select: none prevents text being accidentally selected during drag.
+ */
 body.sr-dragging,
 body.sr-dragging * {
   cursor: grabbing !important;
   user-select: none !important;
 }
+
+/* ── Mode buttons ────────────────────────────────────────────────────────── */
 
 .sr-mode-btn {
   display: flex;
@@ -81,6 +124,7 @@ body.sr-dragging * {
   background: rgba(255, 255, 255, 0.1);
 }
 
+/* Active button uses Red Hat red to match brand */
 .sr-mode-btn.sr-active {
   color: #fff;
   background: #ee0000;
@@ -99,6 +143,8 @@ body.sr-dragging * {
   flex-shrink: 0;
 }
 
+/* ── Separator between buttons ───────────────────────────────────────────── */
+
 .sr-sep {
   width: 1px;
   height: 18px;
@@ -106,7 +152,12 @@ body.sr-dragging * {
   flex-shrink: 0;
 }
 
-/* Collapse to icon-only at narrow widths */
+/* ── Responsive: collapse to icon-only on narrow viewports ──────────────── */
+
+/*
+ * Below 900px the label text disappears and padding tightens.
+ * The icons still convey the mode — labels are supplementary.
+ */
 @media (max-width: 900px) {
   .sr-mode-btn__label {
     display: none;
@@ -117,9 +168,19 @@ body.sr-dragging * {
   }
 }
 
-/* Mode overrides — applied to .app-wrapper */
-/* These use CSS to hide/show panes without touching Split.js inline styles */
+/* ── Mode overrides ──────────────────────────────────────────────────────── */
 
+/*
+ * These classes are toggled on .app-wrapper by the ViewSwitcher component.
+ * We use CSS to show/hide panes rather than modifying Split.js state because
+ * Split.js stores widths in inline styles — changing them from outside its API
+ * causes conflicts when the user resizes the gutter.
+ *
+ * The !important overrides are needed because Split.js sets inline styles
+ * which have higher specificity than class-based rules.
+ */
+
+/* Instructions mode: hide right pane and gutter, expand left to full width */
 .sr-view-instructions .split.right,
 .sr-view-instructions .gutter.gutter-horizontal {
   display: none !important;
@@ -130,6 +191,7 @@ body.sr-dragging * {
   max-width: 100% !important;
 }
 
+/* Tabs mode: hide left pane and gutter, expand right to full width */
 .sr-view-tabs .split.left,
 .sr-view-tabs .gutter.gutter-horizontal {
   display: none !important;

--- a/src/view-switcher.css
+++ b/src/view-switcher.css
@@ -1,16 +1,12 @@
-/* View Switcher — fixed toolbar at top-right for switching between
+/* View Switcher — draggable floating toolbar for switching between
    Instructions / Split / Tabs modes.
-   Space is reserved in .app-split-right__top-bar (via app.css) so the
-   toolbar doesn't visually overlap the tab row. */
+   Default position: bottom-center. User can drag to reposition;
+   position is persisted to localStorage under 'sr-toolbar-pos'. */
 
 .sr-toolbar-wrapper {
   position: fixed;
-  top: 8px;
-  right: 12px;
   z-index: 100;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  /* left/top are set via inline style from React state */
 }
 
 .sr-toolbar {
@@ -22,6 +18,36 @@
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25), 0 0 0 1px rgba(255, 255, 255, 0.08);
   padding: 3px;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Drag handle — grip dots on the left of the toolbar */
+.sr-drag-handle {
+  display: flex;
+  align-items: center;
+  padding: 4px 8px 4px 6px;
+  cursor: grab;
+  color: #555;
+  border-right: 1px solid rgba(255, 255, 255, 0.12);
+  margin-right: 2px;
+  border-radius: 5px 0 0 5px;
+  transition: color 0.15s;
+}
+
+.sr-drag-handle:hover {
+  color: #aaa;
+}
+
+.sr-drag-handle svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+/* Applied to body during drag to enforce grab cursor everywhere */
+body.sr-dragging,
+body.sr-dragging * {
+  cursor: grabbing !important;
+  user-select: none !important;
 }
 
 .sr-mode-btn {
@@ -71,32 +97,6 @@
   flex-shrink: 0;
 }
 
-/* First-visit hint — positioned below the toolbar */
-.sr-hint {
-  margin-top: 6px;
-  z-index: 100;
-  background: #1a1a1a;
-  color: #ccc;
-  font-size: 12px;
-  padding: 8px 14px;
-  border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  white-space: nowrap;
-  opacity: 1;
-  transition: opacity 0.5s;
-  pointer-events: none;
-}
-
-.sr-hint::before {
-  content: '';
-  position: absolute;
-  bottom: 100%;
-  right: 24px;
-  border: 6px solid transparent;
-  border-bottom-color: #1a1a1a;
-}
-
 /* Collapse to icon-only at narrow widths */
 @media (max-width: 900px) {
   .sr-mode-btn__label {
@@ -108,7 +108,7 @@
   }
 }
 
-/* Mode overrides — applied to .app-wrapper or body */
+/* Mode overrides — applied to .app-wrapper */
 /* These use CSS to hide/show panes without touching Split.js inline styles */
 
 .sr-view-instructions .split.right,

--- a/src/view-switcher.css
+++ b/src/view-switcher.css
@@ -5,8 +5,12 @@
 
 .sr-toolbar-wrapper {
   position: fixed;
+  left: 0;
+  top: 0;
   z-index: 100;
-  /* left/top are set via inline style from React state */
+  /* Position applied via transform: translate(x, y) — GPU-composited, no layout reflow */
+  will-change: transform;
+  touch-action: none;
 }
 
 .sr-toolbar {
@@ -24,23 +28,28 @@
 .sr-drag-handle {
   display: flex;
   align-items: center;
-  padding: 4px 8px 4px 6px;
+  padding: 6px 10px 6px 8px;
   cursor: grab;
   color: #555;
   border-right: 1px solid rgba(255, 255, 255, 0.12);
   margin-right: 2px;
   border-radius: 5px 0 0 5px;
   transition: color 0.15s;
+  /* Larger hit area so it's easier to grab */
+  min-width: 28px;
+  justify-content: center;
 }
 
 .sr-drag-handle:hover {
-  color: #aaa;
+  color: #bbb;
+  background: rgba(255, 255, 255, 0.07);
 }
 
 .sr-drag-handle svg {
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   flex-shrink: 0;
+  pointer-events: none;
 }
 
 /* Applied to body during drag to enforce grab cursor everywhere */

--- a/src/view-switcher.css
+++ b/src/view-switcher.css
@@ -94,8 +94,7 @@
  * to the default arrow cursor.
  * user-select: none prevents text being accidentally selected during drag.
  */
-body.sr-dragging,
-body.sr-dragging * {
+body.sr-dragging {
   cursor: grabbing !important;
   user-select: none !important;
 }

--- a/src/view-switcher.tsx
+++ b/src/view-switcher.tsx
@@ -19,12 +19,24 @@ function clamp(val: number, min: number, max: number) {
   return Math.max(min, Math.min(max, val));
 }
 
-function getDefaultPos(): Pos {
-  // Bottom-center, 16px from bottom edge
+// Toolbar approximate dimensions for clamping
+const TOOLBAR_W = 280;
+const TOOLBAR_H = 44;
+const MARGIN = 8;
+
+function clampPos(x: number, y: number): Pos {
   return {
-    x: Math.max(0, window.innerWidth / 2 - 150),
-    y: Math.max(0, window.innerHeight - 56),
+    x: clamp(x, MARGIN, window.innerWidth  - TOOLBAR_W - MARGIN),
+    y: clamp(y, MARGIN, window.innerHeight - TOOLBAR_H - MARGIN),
   };
+}
+
+function getDefaultPos(): Pos {
+  // Bottom-center, just above the browser chrome
+  return clampPos(
+    window.innerWidth / 2 - TOOLBAR_W / 2,
+    window.innerHeight - TOOLBAR_H - 24,
+  );
 }
 
 function getSavedPos(): Pos | null {
@@ -32,7 +44,15 @@ function getSavedPos(): Pos | null {
     const raw = window.localStorage.getItem(POS_KEY);
     if (!raw) return null;
     const p = JSON.parse(raw);
-    if (typeof p.x === 'number' && typeof p.y === 'number') return p;
+    if (typeof p.x !== 'number' || typeof p.y !== 'number') return null;
+    // Validate against current viewport — discard if out of bounds
+    const clamped = clampPos(p.x, p.y);
+    if (Math.abs(clamped.x - p.x) > 200 || Math.abs(clamped.y - p.y) > 200) {
+      // Position is wildly off-screen — discard it
+      window.localStorage.removeItem(POS_KEY);
+      return null;
+    }
+    return clamped;
   } catch (_e) {}
   return null;
 }
@@ -90,9 +110,7 @@ function getInitialMode(defaultMode: ViewMode): ViewMode {
   try {
     const fromStore = window.localStorage.getItem(STORE_KEY);
     if (isViewMode(fromStore)) return fromStore;
-  } catch (_e) {
-    // localStorage unavailable
-  }
+  } catch (_e) {}
   return defaultMode;
 }
 
@@ -106,57 +124,83 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
   const [mode, setMode] = useState<ViewMode>(() => getInitialMode(defaultMode));
   const [pos, setPos] = useState<Pos>(() => getSavedPos() ?? getDefaultPos());
 
-  // posRef lets the document-level mouseup handler read current position
-  // without a stale closure (handlers are registered once with empty deps).
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const posRef = useRef(pos);
   useEffect(() => { posRef.current = pos; }, [pos]);
 
-  const wrapperRef = useRef<HTMLDivElement>(null);
-  const dragOrigin = useRef<{ mouseX: number; mouseY: number; elemX: number; elemY: number } | null>(null);
-
-  // Register drag handlers on document so dragging outside the element works
+  // Re-clamp position when the window is resized so the toolbar never goes off-screen
   useEffect(() => {
-    function onMouseMove(e: MouseEvent) {
-      if (!dragOrigin.current || !wrapperRef.current) return;
-      const dx = e.clientX - dragOrigin.current.mouseX;
-      const dy = e.clientY - dragOrigin.current.mouseY;
-      // Apply directly to DOM — bypasses React re-render per frame for smoothness
-      wrapperRef.current.style.left = `${dragOrigin.current.elemX + dx}px`;
-      wrapperRef.current.style.top  = `${dragOrigin.current.elemY + dy}px`;
-    }
-
-    function onMouseUp(e: MouseEvent) {
-      if (!dragOrigin.current) return;
-      const dx = e.clientX - dragOrigin.current.mouseX;
-      const dy = e.clientY - dragOrigin.current.mouseY;
-      const newX = clamp(dragOrigin.current.elemX + dx, 0, window.innerWidth  - 80);
-      const newY = clamp(dragOrigin.current.elemY + dy, 0, window.innerHeight - 40);
-      dragOrigin.current = null;
-      document.body.classList.remove('sr-dragging');
-      const newPos = { x: newX, y: newY };
-      setPos(newPos);
+    function onResize() {
+      const clamped = clampPos(posRef.current.x, posRef.current.y);
+      setPos(clamped);
       try {
-        window.localStorage.setItem(POS_KEY, JSON.stringify(newPos));
+        window.localStorage.setItem(POS_KEY, JSON.stringify(clamped));
       } catch (_e) {}
     }
-
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup',   onMouseUp);
-    return () => {
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup',   onMouseUp);
-    };
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
   }, []);
 
-  function onDragHandleMouseDown(e: React.MouseEvent) {
+  // Drag state held in a ref — avoids stale closures and skips React re-renders during drag
+  const drag = useRef<{
+    pointerId: number;
+    startPointerX: number;
+    startPointerY: number;
+    startElemX: number;
+    startElemY: number;
+  } | null>(null);
+
+  // Apply transform directly — GPU-composited, no layout reflow
+  function applyTransform(x: number, y: number) {
+    if (wrapperRef.current) {
+      wrapperRef.current.style.transform = `translate(${x}px, ${y}px)`;
+    }
+  }
+
+  // Sync transform whenever pos state changes
+  useEffect(() => {
+    applyTransform(pos.x, pos.y);
+  }, [pos]);
+
+  // Pointer capture approach — no document-level listeners needed.
+  // All pointer events (move, up, cancel) are automatically routed to the
+  // capturing element even if the pointer leaves the window.
+  function onPointerDown(e: React.PointerEvent<HTMLDivElement>) {
     e.preventDefault();
+    (e.currentTarget as HTMLDivElement).setPointerCapture(e.pointerId);
     document.body.classList.add('sr-dragging');
-    dragOrigin.current = {
-      mouseX: e.clientX,
-      mouseY: e.clientY,
-      elemX:  posRef.current.x,
-      elemY:  posRef.current.y,
+    drag.current = {
+      pointerId:     e.pointerId,
+      startPointerX: e.clientX,
+      startPointerY: e.clientY,
+      startElemX:    pos.x,
+      startElemY:    pos.y,
     };
+  }
+
+  function onPointerMove(e: React.PointerEvent<HTMLDivElement>) {
+    if (!drag.current) return;
+    const dx = e.clientX - drag.current.startPointerX;
+    const dy = e.clientY - drag.current.startPointerY;
+    const { x, y } = clampPos(drag.current.startElemX + dx, drag.current.startElemY + dy);
+    // Direct DOM update — smooth, no React re-render per frame
+    applyTransform(x, y);
+  }
+
+  function onPointerUp(e: React.PointerEvent<HTMLDivElement>) {
+    if (!drag.current) return;
+    document.body.classList.remove('sr-dragging');
+    const dx = e.clientX - drag.current.startPointerX;
+    const dy = e.clientY - drag.current.startPointerY;
+    drag.current = null;
+    const newPos = clampPos(
+      pos.x + dx,
+      pos.y + dy,
+    );
+    setPos(newPos);
+    try {
+      window.localStorage.setItem(POS_KEY, JSON.stringify(newPos));
+    } catch (_e) {}
   }
 
   useEffect(() => {
@@ -181,12 +225,14 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
     <div
       ref={wrapperRef}
       className="sr-toolbar-wrapper"
-      style={{ left: pos.x, top: pos.y }}
     >
-      <div className="sr-toolbar" onClick={() => window.focus()} role="toolbar" aria-label="View mode switcher">
+      <div className="sr-toolbar" role="toolbar" aria-label="View mode switcher">
         <div
           className="sr-drag-handle"
-          onMouseDown={onDragHandleMouseDown}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
           title="Drag to reposition"
         >
           <IcoDrag />

--- a/src/view-switcher.tsx
+++ b/src/view-switcher.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 import './view-switcher.css';
 
@@ -11,6 +11,31 @@ type ViewSwitcherProps = {
 };
 
 const STORE_KEY = 'sr-panel-mode';
+const POS_KEY = 'sr-toolbar-pos';
+
+type Pos = { x: number; y: number };
+
+function clamp(val: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, val));
+}
+
+function getDefaultPos(): Pos {
+  // Bottom-center, 16px from bottom edge
+  return {
+    x: Math.max(0, window.innerWidth / 2 - 150),
+    y: Math.max(0, window.innerHeight - 56),
+  };
+}
+
+function getSavedPos(): Pos | null {
+  try {
+    const raw = window.localStorage.getItem(POS_KEY);
+    if (!raw) return null;
+    const p = JSON.parse(raw);
+    if (typeof p.x === 'number' && typeof p.y === 'number') return p;
+  } catch (_e) {}
+  return null;
+}
 
 const IcoDoc = () => (
   <svg viewBox="0 0 24 24">
@@ -27,6 +52,18 @@ const IcoSplit = () => (
 const IcoTabs = () => (
   <svg viewBox="0 0 24 24">
     <path d="M21 3H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H3V5h10v4h8v10zM15 5h2v2h-2V5zm4 0h2v2h-2V5z" />
+  </svg>
+);
+
+// Six-dot grip icon for the drag handle
+const IcoDrag = () => (
+  <svg viewBox="0 0 24 24" aria-hidden="true">
+    <circle cx="9"  cy="7"  r="1.5" fill="currentColor" />
+    <circle cx="15" cy="7"  r="1.5" fill="currentColor" />
+    <circle cx="9"  cy="12" r="1.5" fill="currentColor" />
+    <circle cx="15" cy="12" r="1.5" fill="currentColor" />
+    <circle cx="9"  cy="17" r="1.5" fill="currentColor" />
+    <circle cx="15" cy="17" r="1.5" fill="currentColor" />
   </svg>
 );
 
@@ -60,22 +97,74 @@ function getInitialMode(defaultMode: ViewMode): ViewMode {
 }
 
 const buttons: { mode: ViewMode; Icon: React.FC; label: string; title: string }[] = [
-  { mode: 'instructions', Icon: IcoDoc, label: 'Instructions', title: 'Full-width instructions' },
-  { mode: 'split', Icon: IcoSplit, label: 'Split', title: 'Side by side' },
-  { mode: 'tabs', Icon: IcoTabs, label: 'Tabs', title: 'Full-width tabs' },
+  { mode: 'instructions', Icon: IcoDoc,   label: 'Instructions', title: 'Full-width instructions' },
+  { mode: 'split',        Icon: IcoSplit, label: 'Split',        title: 'Side by side' },
+  { mode: 'tabs',         Icon: IcoTabs,  label: 'Tabs',         title: 'Full-width tabs' },
 ];
 
 export default function ViewSwitcher({ defaultMode = 'split', onModeChange, persistUrlState }: ViewSwitcherProps) {
   const [mode, setMode] = useState<ViewMode>(() => getInitialMode(defaultMode));
+  const [pos, setPos] = useState<Pos>(() => getSavedPos() ?? getDefaultPos());
+
+  // posRef lets the document-level mouseup handler read current position
+  // without a stale closure (handlers are registered once with empty deps).
+  const posRef = useRef(pos);
+  useEffect(() => { posRef.current = pos; }, [pos]);
+
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const dragOrigin = useRef<{ mouseX: number; mouseY: number; elemX: number; elemY: number } | null>(null);
+
+  // Register drag handlers on document so dragging outside the element works
+  useEffect(() => {
+    function onMouseMove(e: MouseEvent) {
+      if (!dragOrigin.current || !wrapperRef.current) return;
+      const dx = e.clientX - dragOrigin.current.mouseX;
+      const dy = e.clientY - dragOrigin.current.mouseY;
+      // Apply directly to DOM — bypasses React re-render per frame for smoothness
+      wrapperRef.current.style.left = `${dragOrigin.current.elemX + dx}px`;
+      wrapperRef.current.style.top  = `${dragOrigin.current.elemY + dy}px`;
+    }
+
+    function onMouseUp(e: MouseEvent) {
+      if (!dragOrigin.current) return;
+      const dx = e.clientX - dragOrigin.current.mouseX;
+      const dy = e.clientY - dragOrigin.current.mouseY;
+      const newX = clamp(dragOrigin.current.elemX + dx, 0, window.innerWidth  - 80);
+      const newY = clamp(dragOrigin.current.elemY + dy, 0, window.innerHeight - 40);
+      dragOrigin.current = null;
+      document.body.classList.remove('sr-dragging');
+      const newPos = { x: newX, y: newY };
+      setPos(newPos);
+      try {
+        window.localStorage.setItem(POS_KEY, JSON.stringify(newPos));
+      } catch (_e) {}
+    }
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup',   onMouseUp);
+    return () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup',   onMouseUp);
+    };
+  }, []);
+
+  function onDragHandleMouseDown(e: React.MouseEvent) {
+    e.preventDefault();
+    document.body.classList.add('sr-dragging');
+    dragOrigin.current = {
+      mouseX: e.clientX,
+      mouseY: e.clientY,
+      elemX:  posRef.current.x,
+      elemY:  posRef.current.y,
+    };
+  }
 
   useEffect(() => {
     onModeChange(mode);
     if (persistUrlState) setUrlViewParam(mode);
     try {
       window.localStorage.setItem(STORE_KEY, mode);
-    } catch (_e) {
-      // no-op
-    }
+    } catch (_e) {}
   }, [mode, onModeChange, persistUrlState]);
 
   useEffect(() => {
@@ -88,13 +177,20 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
     return () => window.removeEventListener('popstate', handlePopState);
   }, [persistUrlState]);
 
-  function handleToolbarClick() {
-    window.focus();
-  }
-
   return (
-    <div className="sr-toolbar-wrapper">
-      <div className="sr-toolbar" onClick={handleToolbarClick} role="toolbar" aria-label="View mode switcher">
+    <div
+      ref={wrapperRef}
+      className="sr-toolbar-wrapper"
+      style={{ left: pos.x, top: pos.y }}
+    >
+      <div className="sr-toolbar" onClick={() => window.focus()} role="toolbar" aria-label="View mode switcher">
+        <div
+          className="sr-drag-handle"
+          onMouseDown={onDragHandleMouseDown}
+          title="Drag to reposition"
+        >
+          <IcoDrag />
+        </div>
         {buttons.map((btn, i) => (
           <React.Fragment key={btn.mode}>
             {i > 0 && <div className="sr-sep" aria-hidden="true" />}

--- a/src/view-switcher.tsx
+++ b/src/view-switcher.tsx
@@ -1,3 +1,23 @@
+/**
+ * ViewSwitcher — draggable floating toolbar for switching panel layout.
+ *
+ * Layout modes:
+ *   instructions — left panel only (full width)
+ *   split        — left + right panels side by side (default)
+ *   tabs         — right panel only (full width)
+ *
+ * Drag behaviour:
+ *   - User grabs the grip handle on the left of the toolbar
+ *   - Uses Pointer Capture API so events keep routing to the handle
+ *     even if the pointer leaves the browser window mid-drag
+ *   - Position is applied via CSS transform (GPU-composited, no layout reflow)
+ *   - Final position is saved to localStorage so it survives page reloads
+ *   - On window resize, position is re-clamped so the toolbar never goes off-screen
+ *
+ * localStorage keys:
+ *   sr-panel-mode — last selected view mode (instructions | split | tabs)
+ *   sr-toolbar-pos — last drag position { x, y } in viewport pixels
+ */
 import React, { useState, useEffect, useRef } from 'react';
 
 import './view-switcher.css';
@@ -7,23 +27,32 @@ export type ViewMode = 'instructions' | 'split' | 'tabs';
 type ViewSwitcherProps = {
   defaultMode?: ViewMode;
   onModeChange: (mode: ViewMode) => void;
+  /** When true, the ?view= URL param is kept in sync with the active mode */
   persistUrlState?: boolean;
 };
 
-const STORE_KEY = 'sr-panel-mode';
-const POS_KEY = 'sr-toolbar-pos';
+// localStorage keys
+const STORE_KEY = 'sr-panel-mode';   // persists the selected view mode
+const POS_KEY   = 'sr-toolbar-pos';  // persists the drag position { x, y }
 
 type Pos = { x: number; y: number };
+
+// ─── Clamping helpers ────────────────────────────────────────────────────────
 
 function clamp(val: number, min: number, max: number) {
   return Math.max(min, Math.min(max, val));
 }
 
-// Toolbar approximate dimensions for clamping
+/**
+ * Approximate toolbar size used for viewport clamping.
+ * These don't need to be pixel-perfect — they just keep the toolbar
+ * from being dragged entirely off-screen.
+ */
 const TOOLBAR_W = 280;
 const TOOLBAR_H = 44;
-const MARGIN = 8;
+const MARGIN    = 8;   // minimum gap from viewport edges
 
+/** Returns a position clamped so the toolbar stays fully within the viewport. */
 function clampPos(x: number, y: number): Pos {
   return {
     x: clamp(x, MARGIN, window.innerWidth  - TOOLBAR_W - MARGIN),
@@ -31,24 +60,31 @@ function clampPos(x: number, y: number): Pos {
   };
 }
 
+/** Default position: bottom-center, 24px above the browser chrome. */
 function getDefaultPos(): Pos {
-  // Bottom-center, just above the browser chrome
   return clampPos(
     window.innerWidth / 2 - TOOLBAR_W / 2,
     window.innerHeight - TOOLBAR_H - 24,
   );
 }
 
+/**
+ * Reads the saved position from localStorage and validates it.
+ * If the stored position is wildly off-screen (e.g. saved on a larger
+ * monitor, or corrupted), it is discarded and null is returned so the
+ * caller falls back to the default position.
+ */
 function getSavedPos(): Pos | null {
   try {
     const raw = window.localStorage.getItem(POS_KEY);
     if (!raw) return null;
     const p = JSON.parse(raw);
     if (typeof p.x !== 'number' || typeof p.y !== 'number') return null;
-    // Validate against current viewport — discard if out of bounds
+
+    // Clamp and compare — if the stored value needed more than 200px of
+    // correction it is from a very different viewport; start fresh instead.
     const clamped = clampPos(p.x, p.y);
     if (Math.abs(clamped.x - p.x) > 200 || Math.abs(clamped.y - p.y) > 200) {
-      // Position is wildly off-screen — discard it
       window.localStorage.removeItem(POS_KEY);
       return null;
     }
@@ -57,25 +93,30 @@ function getSavedPos(): Pos | null {
   return null;
 }
 
+// ─── Icons ───────────────────────────────────────────────────────────────────
+
+/** Instructions mode — document icon */
 const IcoDoc = () => (
   <svg viewBox="0 0 24 24">
     <path d="M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zM6 20V4h7v5h5v11H6z" />
   </svg>
 );
 
+/** Split mode — two-column icon */
 const IcoSplit = () => (
   <svg viewBox="0 0 24 24">
     <path d="M3 3h8v18H3V3zm10 0h8v18h-8V3zM5 5v14h4V5H5zm10 0v14h4V5h-4z" />
   </svg>
 );
 
+/** Tabs mode — tabbed panel icon */
 const IcoTabs = () => (
   <svg viewBox="0 0 24 24">
     <path d="M21 3H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H3V5h10v4h8v10zM15 5h2v2h-2V5zm4 0h2v2h-2V5z" />
   </svg>
 );
 
-// Six-dot grip icon for the drag handle
+/** Six-dot grip — drag handle visual indicator */
 const IcoDrag = () => (
   <svg viewBox="0 0 24 24" aria-hidden="true">
     <circle cx="9"  cy="7"  r="1.5" fill="currentColor" />
@@ -86,6 +127,8 @@ const IcoDrag = () => (
     <circle cx="15" cy="17" r="1.5" fill="currentColor" />
   </svg>
 );
+
+// ─── Mode helpers ─────────────────────────────────────────────────────────────
 
 const VALID_MODES: ViewMode[] = ['instructions', 'split', 'tabs'];
 
@@ -104,6 +147,12 @@ function setUrlViewParam(mode: ViewMode) {
   window.history.replaceState(null, '', url.toString());
 }
 
+/**
+ * Priority order for initial mode:
+ *   1. ?view= URL param (shareable link, deeplink support)
+ *   2. localStorage (user's last choice)
+ *   3. defaultMode prop (catalog-configured default)
+ */
 function getInitialMode(defaultMode: ViewMode): ViewMode {
   const fromUrl = getUrlViewParam();
   if (fromUrl) return fromUrl;
@@ -114,21 +163,32 @@ function getInitialMode(defaultMode: ViewMode): ViewMode {
   return defaultMode;
 }
 
+// Button definitions — order controls left-to-right rendering
 const buttons: { mode: ViewMode; Icon: React.FC; label: string; title: string }[] = [
   { mode: 'instructions', Icon: IcoDoc,   label: 'Instructions', title: 'Full-width instructions' },
   { mode: 'split',        Icon: IcoSplit, label: 'Split',        title: 'Side by side' },
   { mode: 'tabs',         Icon: IcoTabs,  label: 'Tabs',         title: 'Full-width tabs' },
 ];
 
+// ─── Component ────────────────────────────────────────────────────────────────
+
 export default function ViewSwitcher({ defaultMode = 'split', onModeChange, persistUrlState }: ViewSwitcherProps) {
   const [mode, setMode] = useState<ViewMode>(() => getInitialMode(defaultMode));
+
+  // pos drives the CSS transform that positions the toolbar.
+  // Initialised from localStorage if valid, otherwise default (bottom-center).
   const [pos, setPos] = useState<Pos>(() => getSavedPos() ?? getDefaultPos());
 
   const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // posRef mirrors pos state so the resize handler always reads the latest
+  // value without being re-registered every time pos changes.
   const posRef = useRef(pos);
   useEffect(() => { posRef.current = pos; }, [pos]);
 
-  // Re-clamp position when the window is resized so the toolbar never goes off-screen
+  // ── Resize handling ──────────────────────────────────────────────────────
+  // When the viewport shrinks, a previously valid position might be off-screen.
+  // Re-clamp on every resize and persist the corrected value.
   useEffect(() => {
     function onResize() {
       const clamped = clampPos(posRef.current.x, posRef.current.y);
@@ -141,34 +201,42 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
     return () => window.removeEventListener('resize', onResize);
   }, []);
 
-  // Drag state held in a ref — avoids stale closures and skips React re-renders during drag
+  // ── Drag state ───────────────────────────────────────────────────────────
+  // Stored in a ref rather than state — we don't want React re-renders during
+  // drag; position updates go directly to the DOM via applyTransform().
   const drag = useRef<{
-    pointerId: number;
-    startPointerX: number;
+    pointerId:     number;  // identifies which pointer is dragging (multi-touch safety)
+    startPointerX: number;  // pointer position at drag start
     startPointerY: number;
-    startElemX: number;
-    startElemY: number;
+    startElemX:    number;  // toolbar position at drag start
+    startElemY:    number;
   } | null>(null);
 
-  // Apply transform directly — GPU-composited, no layout reflow
+  // ── Transform helper ─────────────────────────────────────────────────────
+  // Writes directly to the DOM style — GPU-composited via CSS transform,
+  // does not trigger layout or paint on the main thread.
   function applyTransform(x: number, y: number) {
     if (wrapperRef.current) {
       wrapperRef.current.style.transform = `translate(${x}px, ${y}px)`;
     }
   }
 
-  // Sync transform whenever pos state changes
+  // Sync transform whenever pos state changes (initial render + after drag/resize)
   useEffect(() => {
     applyTransform(pos.x, pos.y);
   }, [pos]);
 
-  // Pointer capture approach — no document-level listeners needed.
-  // All pointer events (move, up, cancel) are automatically routed to the
-  // capturing element even if the pointer leaves the window.
+  // ── Pointer event handlers ───────────────────────────────────────────────
+  //
+  // We use the Pointer Capture API instead of document-level mousemove/mouseup.
+  // setPointerCapture() routes all subsequent pointer events for that pointer ID
+  // to this element — even if the cursor leaves the browser window — so the drag
+  // cannot get "stuck" when the user releases outside the viewport.
+
   function onPointerDown(e: React.PointerEvent<HTMLDivElement>) {
-    e.preventDefault();
+    e.preventDefault(); // prevent text selection starting during drag
     (e.currentTarget as HTMLDivElement).setPointerCapture(e.pointerId);
-    document.body.classList.add('sr-dragging');
+    document.body.classList.add('sr-dragging'); // enforces grabbing cursor globally
     drag.current = {
       pointerId:     e.pointerId,
       startPointerX: e.clientX,
@@ -182,9 +250,9 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
     if (!drag.current) return;
     const dx = e.clientX - drag.current.startPointerX;
     const dy = e.clientY - drag.current.startPointerY;
+    // Clamp during move too — toolbar never leaves the viewport even mid-drag
     const { x, y } = clampPos(drag.current.startElemX + dx, drag.current.startElemY + dy);
-    // Direct DOM update — smooth, no React re-render per frame
-    applyTransform(x, y);
+    applyTransform(x, y); // direct DOM write — no React re-render per frame
   }
 
   function onPointerUp(e: React.PointerEvent<HTMLDivElement>) {
@@ -193,16 +261,18 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
     const dx = e.clientX - drag.current.startPointerX;
     const dy = e.clientY - drag.current.startPointerY;
     drag.current = null;
-    const newPos = clampPos(
-      pos.x + dx,
-      pos.y + dy,
-    );
+
+    const newPos = clampPos(pos.x + dx, pos.y + dy);
+
+    // Commit final position to React state (triggers re-render with correct transform)
+    // and persist to localStorage for next page load.
     setPos(newPos);
     try {
       window.localStorage.setItem(POS_KEY, JSON.stringify(newPos));
     } catch (_e) {}
   }
 
+  // ── Mode persistence & URL sync ──────────────────────────────────────────
   useEffect(() => {
     onModeChange(mode);
     if (persistUrlState) setUrlViewParam(mode);
@@ -211,6 +281,7 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
     } catch (_e) {}
   }, [mode, onModeChange, persistUrlState]);
 
+  // Sync mode from URL when the user navigates back/forward
   useEffect(() => {
     if (!persistUrlState) return;
     function handlePopState() {
@@ -221,12 +292,19 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
     return () => window.removeEventListener('popstate', handlePopState);
   }, [persistUrlState]);
 
+  // ── Render ───────────────────────────────────────────────────────────────
   return (
+    // Wrapper is position:fixed at (0,0); actual position comes from the CSS transform.
+    // This keeps the stacking context clean and avoids left/top triggering layout.
     <div
       ref={wrapperRef}
       className="sr-toolbar-wrapper"
     >
       <div className="sr-toolbar" role="toolbar" aria-label="View mode switcher">
+
+        {/* Drag handle — the only part of the toolbar that initiates dragging.
+            onPointerCancel mirrors onPointerUp so a cancelled pointer (e.g. phone
+            call interruption on mobile) still cleans up drag state correctly. */}
         <div
           className="sr-drag-handle"
           onPointerDown={onPointerDown}
@@ -237,6 +315,8 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
         >
           <IcoDrag />
         </div>
+
+        {/* Mode buttons — clicking these does NOT start a drag */}
         {buttons.map((btn, i) => (
           <React.Fragment key={btn.mode}>
             {i > 0 && <div className="sr-sep" aria-hidden="true" />}

--- a/src/view-switcher.tsx
+++ b/src/view-switcher.tsx
@@ -1,24 +1,30 @@
 /**
- * ViewSwitcher — draggable floating toolbar for switching panel layout.
+ * ViewSwitcher — edge-snapping floating toolbar for switching panel layout.
  *
  * Layout modes:
  *   instructions — left panel only (full width)
  *   split        — left + right panels side by side (default)
  *   tabs         — right panel only (full width)
  *
+ * Positioning:
+ *   The toolbar snaps to one of 6 anchor points along the top and bottom
+ *   viewport edges (top-left, top-center, top-right, bottom-left,
+ *   bottom-center, bottom-right). Dragging moves it freely; on release it
+ *   snaps to the nearest anchor with a short ease-out animation.
+ *
  * Drag behaviour:
  *   - User grabs the grip handle on the left of the toolbar
  *   - Uses Pointer Capture API so events keep routing to the handle
  *     even if the pointer leaves the browser window mid-drag
  *   - Position is applied via CSS transform (GPU-composited, no layout reflow)
- *   - Final position is saved to localStorage so it survives page reloads
- *   - On window resize, position is re-clamped so the toolbar never goes off-screen
+ *   - On release, findNearestAnchor() picks the closest snap point
+ *   - The sr-snapping CSS class enables a transition for the snap animation
  *
  * localStorage keys:
- *   sr-panel-mode — last selected view mode (instructions | split | tabs)
- *   sr-toolbar-pos — last drag position { x, y } in viewport pixels
+ *   sr-panel-mode      — last selected view mode (instructions | split | tabs)
+ *   sr-toolbar-anchor  — last snap anchor name (e.g. "bottom-center")
  */
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react';
 
 import './view-switcher.css';
 
@@ -26,72 +32,80 @@ export type ViewMode = 'instructions' | 'split' | 'tabs';
 
 type ViewSwitcherProps = {
   defaultMode?: ViewMode;
+  /**
+   * Called whenever the active mode changes. Internally stabilised via a ref
+   * so consumers do not need to wrap this in useCallback — passing an inline
+   * arrow or a state setter directly is safe and will not cause extra renders.
+   */
   onModeChange: (mode: ViewMode) => void;
   /** When true, the ?view= URL param is kept in sync with the active mode */
   persistUrlState?: boolean;
 };
 
 // localStorage keys
-const STORE_KEY = 'sr-panel-mode';   // persists the selected view mode
-const POS_KEY   = 'sr-toolbar-pos';  // persists the drag position { x, y }
+const STORE_KEY  = 'sr-panel-mode';
+const ANCHOR_KEY = 'sr-toolbar-anchor';
 
 type Pos = { x: number; y: number };
 
-// ─── Clamping helpers ────────────────────────────────────────────────────────
+// ─── Anchor system ────────────────────────────────────────────────────────────
 
-function clamp(val: number, min: number, max: number) {
-  return Math.max(min, Math.min(max, val));
-}
+type Anchor =
+  | 'top-left' | 'top-center' | 'top-right'
+  | 'bottom-left' | 'bottom-center' | 'bottom-right';
 
-/**
- * Fallback toolbar dimensions used before the first DOM measurement.
- * After mount the component measures the real size via getBoundingClientRect
- * and stores it in a ref, so responsive breakpoint changes (e.g. labels
- * hidden below 900px) are handled correctly.
- */
+const ALL_ANCHORS: Anchor[] = [
+  'top-left', 'top-center', 'top-right',
+  'bottom-left', 'bottom-center', 'bottom-right',
+];
+
 const FALLBACK_W = 280;
 const FALLBACK_H = 44;
 const MARGIN     = 8;
 
-/** Returns a position clamped so the toolbar stays fully within the viewport. */
-function clampPos(x: number, y: number, toolbarW = FALLBACK_W, toolbarH = FALLBACK_H): Pos {
+/** Compute pixel position for a named anchor given current viewport + toolbar size. */
+function anchorToPos(anchor: Anchor, tw: number, th: number): Pos {
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  switch (anchor) {
+    case 'top-left':      return { x: MARGIN,              y: MARGIN };
+    case 'top-center':    return { x: vw / 2 - tw / 2,    y: MARGIN };
+    case 'top-right':     return { x: vw - tw - MARGIN,    y: MARGIN };
+    case 'bottom-left':   return { x: MARGIN,              y: vh - th - MARGIN };
+    case 'bottom-center': return { x: vw / 2 - tw / 2,    y: vh - th - MARGIN };
+    case 'bottom-right':  return { x: vw - tw - MARGIN,    y: vh - th - MARGIN };
+  }
+}
+
+/** Find the anchor closest (Euclidean) to a free-drag position. */
+function findNearestAnchor(x: number, y: number, tw: number, th: number): Anchor {
+  let best: Anchor = 'bottom-center';
+  let bestDist = Infinity;
+  for (const a of ALL_ANCHORS) {
+    const p = anchorToPos(a, tw, th);
+    const dist = (p.x - x) ** 2 + (p.y - y) ** 2;
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = a;
+    }
+  }
+  return best;
+}
+
+/** Clamp an arbitrary position so the toolbar stays within the viewport during drag. */
+function clampToViewport(x: number, y: number, tw: number, th: number): Pos {
   return {
-    x: clamp(x, MARGIN, window.innerWidth  - toolbarW - MARGIN),
-    y: clamp(y, MARGIN, window.innerHeight - toolbarH - MARGIN),
+    x: Math.max(MARGIN, Math.min(x, window.innerWidth  - tw - MARGIN)),
+    y: Math.max(MARGIN, Math.min(y, window.innerHeight - th - MARGIN)),
   };
 }
 
-/** Default position: bottom-center, 24px above the browser chrome. */
-function getDefaultPos(): Pos {
-  return clampPos(
-    window.innerWidth / 2 - FALLBACK_W / 2,
-    window.innerHeight - FALLBACK_H - 24,
-  );
-}
-
-/**
- * Reads the saved position from localStorage and validates it.
- * If the stored position is wildly off-screen (e.g. saved on a larger
- * monitor, or corrupted), it is discarded and null is returned so the
- * caller falls back to the default position.
- */
-function getSavedPos(): Pos | null {
+function getSavedAnchor(): Anchor {
   try {
-    const raw = window.localStorage.getItem(POS_KEY);
-    if (!raw) return null;
-    const p = JSON.parse(raw);
-    if (typeof p.x !== 'number' || typeof p.y !== 'number') return null;
-
-    // Clamp and compare — if the stored value needed more than 200px of
-    // correction it is from a very different viewport; start fresh instead.
-    const clamped = clampPos(p.x, p.y);
-    if (Math.abs(clamped.x - p.x) > 200 || Math.abs(clamped.y - p.y) > 200) {
-      window.localStorage.removeItem(POS_KEY);
-      return null;
-    }
-    return clamped;
+    const raw = window.localStorage.getItem(ANCHOR_KEY);
+    if (raw && ALL_ANCHORS.includes(raw as Anchor)) return raw as Anchor;
   } catch (_e) {}
-  return null;
+  return 'bottom-center';
 }
 
 // ─── Icons ───────────────────────────────────────────────────────────────────
@@ -175,20 +189,17 @@ const buttons: { mode: ViewMode; Icon: React.FC; label: string; title: string }[
 
 export default function ViewSwitcher({ defaultMode = 'split', onModeChange, persistUrlState }: ViewSwitcherProps) {
   const [mode, setMode] = useState<ViewMode>(() => getInitialMode(defaultMode));
-
-  // pos drives the CSS transform that positions the toolbar.
-  // Initialised from localStorage if valid, otherwise default (bottom-center).
-  const [pos, setPos] = useState<Pos>(() => getSavedPos() ?? getDefaultPos());
+  const [anchor, setAnchor] = useState<Anchor>(getSavedAnchor);
+  const [pos, setPos] = useState<Pos>(() => anchorToPos(getSavedAnchor(), FALLBACK_W, FALLBACK_H));
 
   const wrapperRef = useRef<HTMLDivElement>(null);
-
-  // posRef mirrors pos state so the resize handler always reads the latest
-  // value without being re-registered every time pos changes.
-  const posRef = useRef(pos);
-  useEffect(() => { posRef.current = pos; }, [pos]);
-
-  const toolbarSize = useRef({ w: FALLBACK_W, h: FALLBACK_H });
   const mountedRef = useRef(false);
+  const isSnapping = useRef(false);
+
+  // anchorRef mirrors anchor state so the resize handler always reads the
+  // latest value without being re-registered every time anchor changes.
+  const anchorRef = useRef(anchor);
+  useEffect(() => { anchorRef.current = anchor; }, [anchor]);
 
   // Stabilise the onModeChange callback so the persistence effect doesn't
   // re-run when a consumer passes a new arrow function on each render.
@@ -196,89 +207,97 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
   useEffect(() => { onModeChangeRef.current = onModeChange; }, [onModeChange]);
   const stableOnModeChange = useCallback((m: ViewMode) => onModeChangeRef.current(m), []);
 
-  // ── Resize handling ──────────────────────────────────────────────────────
-  // When the viewport shrinks, a previously valid position might be off-screen.
-  // Re-clamp on every resize and persist the corrected value.
-  useEffect(() => {
-    let saveTimer: ReturnType<typeof setTimeout>;
-
-    function onResize() {
-      // Re-measure — toolbar width changes at the 900px responsive breakpoint
-      if (wrapperRef.current) {
-        const rect = wrapperRef.current.getBoundingClientRect();
-        if (rect.width > 0 && rect.height > 0) {
-          toolbarSize.current = { w: rect.width, h: rect.height };
-        }
-      }
-      const { w, h } = toolbarSize.current;
-      const clamped = clampPos(posRef.current.x, posRef.current.y, w, h);
-      setPos(clamped);
-
-      clearTimeout(saveTimer);
-      saveTimer = setTimeout(() => {
-        try { window.localStorage.setItem(POS_KEY, JSON.stringify(clamped)); } catch (_e) {}
-      }, 200);
+  // ── Toolbar measurement ─────────────────────────────────────────────────
+  function getToolbarSize(): { w: number; h: number } {
+    if (wrapperRef.current) {
+      const rect = wrapperRef.current.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) return { w: rect.width, h: rect.height };
     }
+    return { w: FALLBACK_W, h: FALLBACK_H };
+  }
 
+  // ── Correct position once the real toolbar dimensions are known ─────────
+  // The initial pos state uses FALLBACK_W/H which may differ from the
+  // actual rendered size, pushing the toolbar off-screen on right anchors.
+  useLayoutEffect(() => {
+    const size = getToolbarSize();
+    setPos(anchorToPos(anchorRef.current, size.w, size.h));
+  }, []);
+
+  // ── Resize handling ──────────────────────────────────────────────────────
+  useEffect(() => {
+    function onResize() {
+      const size = getToolbarSize();
+      setPos(anchorToPos(anchorRef.current, size.w, size.h));
+    }
     window.addEventListener('resize', onResize);
-    return () => {
-      window.removeEventListener('resize', onResize);
-      clearTimeout(saveTimer);
-    };
+    return () => window.removeEventListener('resize', onResize);
   }, []);
 
   // ── Drag state ───────────────────────────────────────────────────────────
-  // Stored in a ref rather than state — we don't want React re-renders during
-  // drag; position updates go directly to the DOM via applyTransform().
   const drag = useRef<{
-    pointerId:     number;  // identifies which pointer is dragging (multi-touch safety)
-    startPointerX: number;  // pointer position at drag start
+    pointerId:     number;
+    startPointerX: number;
     startPointerY: number;
-    startElemX:    number;  // toolbar position at drag start
+    startElemX:    number;
     startElemY:    number;
   } | null>(null);
 
   // ── Transform helper ─────────────────────────────────────────────────────
-  // Writes directly to the DOM style — GPU-composited via CSS transform,
-  // does not trigger layout or paint on the main thread.
   function applyTransform(x: number, y: number) {
     if (wrapperRef.current) {
       wrapperRef.current.style.transform = `translate(${x}px, ${y}px)`;
     }
   }
 
-  // Sync transform whenever pos state changes (initial render + after drag/resize)
+  // Sync transform whenever pos state changes (initial render + after snap/resize)
   useEffect(() => {
     applyTransform(pos.x, pos.y);
   }, [pos]);
 
-  // Measure actual toolbar dimensions on mount for accurate clamping
+  // ── Snap animation cleanup ─────────────────────────────────────────────
+  // Remove the sr-snapping class after the CSS transition finishes so it
+  // doesn't interfere with the next drag.
   useEffect(() => {
-    if (wrapperRef.current) {
-      const rect = wrapperRef.current.getBoundingClientRect();
-      if (rect.width > 0 && rect.height > 0) {
-        toolbarSize.current = { w: rect.width, h: rect.height };
-      }
+    const el = wrapperRef.current;
+    if (!el) return;
+    function onTransitionEnd() {
+      isSnapping.current = false;
+      el!.classList.remove('sr-snapping');
     }
+    el.addEventListener('transitionend', onTransitionEnd);
+    return () => el.removeEventListener('transitionend', onTransitionEnd);
   }, []);
 
   // ── Pointer event handlers ───────────────────────────────────────────────
-  //
-  // We use the Pointer Capture API instead of document-level mousemove/mouseup.
-  // setPointerCapture() routes all subsequent pointer events for that pointer ID
-  // to this element — even if the cursor leaves the browser window — so the drag
-  // cannot get "stuck" when the user releases outside the viewport.
 
   function onPointerDown(e: React.PointerEvent<HTMLDivElement>) {
-    e.preventDefault(); // prevent text selection starting during drag
+    e.preventDefault();
     (e.currentTarget as HTMLDivElement).setPointerCapture(e.pointerId);
-    document.body.classList.add('sr-dragging'); // enforces grabbing cursor globally
+
+    let startX = pos.x;
+    let startY = pos.y;
+
+    // Cancel any in-progress snap animation. Read the current visual position
+    // from the DOM since pos state already holds the snap *target* which the
+    // CSS transition may not have reached yet.
+    if (isSnapping.current && wrapperRef.current) {
+      isSnapping.current = false;
+      wrapperRef.current.classList.remove('sr-snapping');
+      const rect = wrapperRef.current.getBoundingClientRect();
+      startX = rect.left;
+      startY = rect.top;
+      applyTransform(startX, startY);
+      setPos({ x: startX, y: startY });
+    }
+
+    document.body.classList.add('sr-dragging');
     drag.current = {
       pointerId:     e.pointerId,
       startPointerX: e.clientX,
       startPointerY: e.clientY,
-      startElemX:    pos.x,
-      startElemY:    pos.y,
+      startElemX:    startX,
+      startElemY:    startY,
     };
   }
 
@@ -286,31 +305,40 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
     if (!drag.current) return;
     const dx = e.clientX - drag.current.startPointerX;
     const dy = e.clientY - drag.current.startPointerY;
-    const { w, h } = toolbarSize.current;
-    const { x, y } = clampPos(drag.current.startElemX + dx, drag.current.startElemY + dy, w, h);
+    const size = getToolbarSize();
+    const { x, y } = clampToViewport(
+      drag.current.startElemX + dx,
+      drag.current.startElemY + dy,
+      size.w, size.h,
+    );
     applyTransform(x, y);
   }
 
   function onPointerUp(e: React.PointerEvent<HTMLDivElement>) {
     if (!drag.current) return;
     document.body.classList.remove('sr-dragging');
+
     const dx = e.clientX - drag.current.startPointerX;
     const dy = e.clientY - drag.current.startPointerY;
-    const startX = drag.current.startElemX;
-    const startY = drag.current.startElemY;
+    const freeX = drag.current.startElemX + dx;
+    const freeY = drag.current.startElemY + dy;
     drag.current = null;
 
-    const { w, h } = toolbarSize.current;
-    const newPos = clampPos(startX + dx, startY + dy, w, h);
-    setPos(newPos);
-    try {
-      window.localStorage.setItem(POS_KEY, JSON.stringify(newPos));
-    } catch (_e) {}
+    // Snap to nearest anchor with animated transition
+    const size = getToolbarSize();
+    const target = findNearestAnchor(freeX, freeY, size.w, size.h);
+    const snapPos = anchorToPos(target, size.w, size.h);
+
+    isSnapping.current = true;
+    wrapperRef.current?.classList.add('sr-snapping');
+    applyTransform(snapPos.x, snapPos.y);
+
+    setAnchor(target);
+    setPos(snapPos);
+    try { window.localStorage.setItem(ANCHOR_KEY, target); } catch (_e) {}
   }
 
   // ── Mode persistence & URL sync ──────────────────────────────────────────
-  // On mount we notify the parent of the initial mode but skip writing back
-  // to localStorage / URL (the value was just read from those sources).
   useEffect(() => {
     stableOnModeChange(mode);
     if (mountedRef.current) {
@@ -335,17 +363,12 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
 
   // ── Render ───────────────────────────────────────────────────────────────
   return (
-    // Wrapper is position:fixed at (0,0); actual position comes from the CSS transform.
-    // This keeps the stacking context clean and avoids left/top triggering layout.
     <div
       ref={wrapperRef}
       className="sr-toolbar-wrapper"
     >
       <div className="sr-toolbar" role="toolbar" aria-label="View mode switcher">
 
-        {/* Drag handle — the only part of the toolbar that initiates dragging.
-            onPointerCancel mirrors onPointerUp so a cancelled pointer (e.g. phone
-            call interruption on mobile) still cleans up drag state correctly. */}
         <div
           className="sr-drag-handle"
           onPointerDown={onPointerDown}
@@ -357,7 +380,6 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
           <IcoDrag />
         </div>
 
-        {/* Mode buttons — clicking these does NOT start a drag */}
         {buttons.map((btn, i) => (
           <React.Fragment key={btn.mode}>
             {i > 0 && <div className="sr-sep" aria-hidden="true" />}

--- a/src/view-switcher.tsx
+++ b/src/view-switcher.tsx
@@ -18,7 +18,7 @@
  *   sr-panel-mode — last selected view mode (instructions | split | tabs)
  *   sr-toolbar-pos — last drag position { x, y } in viewport pixels
  */
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 
 import './view-switcher.css';
 
@@ -44,27 +44,28 @@ function clamp(val: number, min: number, max: number) {
 }
 
 /**
- * Approximate toolbar size used for viewport clamping.
- * These don't need to be pixel-perfect — they just keep the toolbar
- * from being dragged entirely off-screen.
+ * Fallback toolbar dimensions used before the first DOM measurement.
+ * After mount the component measures the real size via getBoundingClientRect
+ * and stores it in a ref, so responsive breakpoint changes (e.g. labels
+ * hidden below 900px) are handled correctly.
  */
-const TOOLBAR_W = 280;
-const TOOLBAR_H = 44;
-const MARGIN    = 8;   // minimum gap from viewport edges
+const FALLBACK_W = 280;
+const FALLBACK_H = 44;
+const MARGIN     = 8;
 
 /** Returns a position clamped so the toolbar stays fully within the viewport. */
-function clampPos(x: number, y: number): Pos {
+function clampPos(x: number, y: number, toolbarW = FALLBACK_W, toolbarH = FALLBACK_H): Pos {
   return {
-    x: clamp(x, MARGIN, window.innerWidth  - TOOLBAR_W - MARGIN),
-    y: clamp(y, MARGIN, window.innerHeight - TOOLBAR_H - MARGIN),
+    x: clamp(x, MARGIN, window.innerWidth  - toolbarW - MARGIN),
+    y: clamp(y, MARGIN, window.innerHeight - toolbarH - MARGIN),
   };
 }
 
 /** Default position: bottom-center, 24px above the browser chrome. */
 function getDefaultPos(): Pos {
   return clampPos(
-    window.innerWidth / 2 - TOOLBAR_W / 2,
-    window.innerHeight - TOOLBAR_H - 24,
+    window.innerWidth / 2 - FALLBACK_W / 2,
+    window.innerHeight - FALLBACK_H - 24,
   );
 }
 
@@ -186,19 +187,44 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
   const posRef = useRef(pos);
   useEffect(() => { posRef.current = pos; }, [pos]);
 
+  const toolbarSize = useRef({ w: FALLBACK_W, h: FALLBACK_H });
+  const mountedRef = useRef(false);
+
+  // Stabilise the onModeChange callback so the persistence effect doesn't
+  // re-run when a consumer passes a new arrow function on each render.
+  const onModeChangeRef = useRef(onModeChange);
+  useEffect(() => { onModeChangeRef.current = onModeChange; }, [onModeChange]);
+  const stableOnModeChange = useCallback((m: ViewMode) => onModeChangeRef.current(m), []);
+
   // ── Resize handling ──────────────────────────────────────────────────────
   // When the viewport shrinks, a previously valid position might be off-screen.
   // Re-clamp on every resize and persist the corrected value.
   useEffect(() => {
+    let saveTimer: ReturnType<typeof setTimeout>;
+
     function onResize() {
-      const clamped = clampPos(posRef.current.x, posRef.current.y);
+      // Re-measure — toolbar width changes at the 900px responsive breakpoint
+      if (wrapperRef.current) {
+        const rect = wrapperRef.current.getBoundingClientRect();
+        if (rect.width > 0 && rect.height > 0) {
+          toolbarSize.current = { w: rect.width, h: rect.height };
+        }
+      }
+      const { w, h } = toolbarSize.current;
+      const clamped = clampPos(posRef.current.x, posRef.current.y, w, h);
       setPos(clamped);
-      try {
-        window.localStorage.setItem(POS_KEY, JSON.stringify(clamped));
-      } catch (_e) {}
+
+      clearTimeout(saveTimer);
+      saveTimer = setTimeout(() => {
+        try { window.localStorage.setItem(POS_KEY, JSON.stringify(clamped)); } catch (_e) {}
+      }, 200);
     }
+
     window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
+    return () => {
+      window.removeEventListener('resize', onResize);
+      clearTimeout(saveTimer);
+    };
   }, []);
 
   // ── Drag state ───────────────────────────────────────────────────────────
@@ -226,6 +252,16 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
     applyTransform(pos.x, pos.y);
   }, [pos]);
 
+  // Measure actual toolbar dimensions on mount for accurate clamping
+  useEffect(() => {
+    if (wrapperRef.current) {
+      const rect = wrapperRef.current.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) {
+        toolbarSize.current = { w: rect.width, h: rect.height };
+      }
+    }
+  }, []);
+
   // ── Pointer event handlers ───────────────────────────────────────────────
   //
   // We use the Pointer Capture API instead of document-level mousemove/mouseup.
@@ -250,9 +286,9 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
     if (!drag.current) return;
     const dx = e.clientX - drag.current.startPointerX;
     const dy = e.clientY - drag.current.startPointerY;
-    // Clamp during move too — toolbar never leaves the viewport even mid-drag
-    const { x, y } = clampPos(drag.current.startElemX + dx, drag.current.startElemY + dy);
-    applyTransform(x, y); // direct DOM write — no React re-render per frame
+    const { w, h } = toolbarSize.current;
+    const { x, y } = clampPos(drag.current.startElemX + dx, drag.current.startElemY + dy, w, h);
+    applyTransform(x, y);
   }
 
   function onPointerUp(e: React.PointerEvent<HTMLDivElement>) {
@@ -260,12 +296,12 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
     document.body.classList.remove('sr-dragging');
     const dx = e.clientX - drag.current.startPointerX;
     const dy = e.clientY - drag.current.startPointerY;
+    const startX = drag.current.startElemX;
+    const startY = drag.current.startElemY;
     drag.current = null;
 
-    const newPos = clampPos(pos.x + dx, pos.y + dy);
-
-    // Commit final position to React state (triggers re-render with correct transform)
-    // and persist to localStorage for next page load.
+    const { w, h } = toolbarSize.current;
+    const newPos = clampPos(startX + dx, startY + dy, w, h);
     setPos(newPos);
     try {
       window.localStorage.setItem(POS_KEY, JSON.stringify(newPos));
@@ -273,13 +309,18 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
   }
 
   // ── Mode persistence & URL sync ──────────────────────────────────────────
+  // On mount we notify the parent of the initial mode but skip writing back
+  // to localStorage / URL (the value was just read from those sources).
   useEffect(() => {
-    onModeChange(mode);
-    if (persistUrlState) setUrlViewParam(mode);
-    try {
-      window.localStorage.setItem(STORE_KEY, mode);
-    } catch (_e) {}
-  }, [mode, onModeChange, persistUrlState]);
+    stableOnModeChange(mode);
+    if (mountedRef.current) {
+      if (persistUrlState) setUrlViewParam(mode);
+      try {
+        window.localStorage.setItem(STORE_KEY, mode);
+      } catch (_e) {}
+    }
+    mountedRef.current = true;
+  }, [mode, stableOnModeChange, persistUrlState]);
 
   // Sync mode from URL when the user navigates back/forward
   useEffect(() => {


### PR DESCRIPTION
Replaces the fixed top-right view-switcher toolbar with a floating, draggable toolbar that snaps to six anchor points along the viewport edges (top/bottom × left/center/right). The toolbar position persists across sessions via localStorage and uses GPU-composited CSS transforms for smooth drag and snap-to-anchor animations.

## Changes
- Add anchor system with 6 snap points and Euclidean nearest-anchor detection for intuitive positioning
- Implement pointer-capture-based drag with grab handle (six-dot grip icon), viewport clamping, and animated snap-on-release
- Persist chosen anchor in localStorage (`sr-toolbar-anchor`) and recalculate position on window resize
- Stabilise `onModeChange` callback via ref to prevent unnecessary re-renders from inline arrow props
- Fix Split.js pane sizing for instructions/tabs modes by passing explicit `[100, 0]` / `[0, 100]` sizes and `minSize: 0`
- Remove static `padding-right` reservation on the tab bar (no longer needed with floating toolbar)
- Replace first-visit hint tooltip CSS with drag handle and snap animation styles

## Notes
- New localStorage key `sr-toolbar-anchor` is introduced; existing `sr-panel-mode` key continues to work unchanged
- Default anchor is `bottom-center`, matching the previous visual position at the bottom of the viewport