### PR TITLE
Support [INFO] prefix for informational solve dialogs

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -37,6 +37,26 @@ function renderLimitedMarkdown(text: string): { __html: string } {
   return { __html: withBreaks };
 }
 
+// Detect [INFO] prefix in output — used to show informational dialogs instead of error dialogs
+function parseOutputType(output: string | undefined): {
+  message: string;
+  title: string;
+  type: 'warning' | 'danger' | 'success' | 'info';
+} {
+  if (output?.startsWith('[INFO]\n') || output?.startsWith('[INFO] ')) {
+    return {
+      message: output.replace(/^\[INFO\]\n?/, ''),
+      title: 'Action Required',
+      type: 'info',
+    };
+  }
+  return {
+    message: output || '',
+    title: 'Validation Error',
+    type: 'danger',
+  };
+}
+
 type ConfigFetchResult = {
   url: string;
   ok: boolean;
@@ -217,7 +237,7 @@ export default function () {
   const version = config?.antora?.version;
   const s_name = config?.antora?.name || 'modules';
   const [validationMsg, setValidationMsg] = useState<{
-    type: 'warning' | 'danger' | 'success';
+    type: 'warning' | 'danger' | 'success' | 'info';
     message: string;
     title: string;
   } | null>(null);
@@ -523,7 +543,8 @@ export default function () {
         setLoaderStatus({ isLoading: false, stage: null });
       } else {
         setLoaderStatus({ isLoading: false, stage: null });
-        setValidationMsg({ message: res.Output || '', title: 'Validation Error', type: 'danger' });
+        // If output starts with [INFO], show as informational dialog instead of error
+        setValidationMsg(parseOutputType(res.Output));
       }
     }
   }


### PR DESCRIPTION
## Problem

When a solve script needs to show informational instructions to the user (e.g. "complete these manual GitHub steps before proceeding"), it must fail the play to surface output via `validation_failure.out`. This results in a red **"Validation Error"** dialog even though the content is informational, not an error.

## Solution

Add a `parseOutputType()` helper that detects a `[INFO]` prefix in solve output and renders it as a blue **"Action Required"** info dialog instead of a red error dialog.

**Usage** — in any solve/validation script, prefix the output with `[INFO]\n`:
```yaml
- name: Write informational message
  ansible.builtin.copy:
    content: |
      [INFO]
      Action Required: Complete these steps manually before clicking Next...
    dest: "{{ job_info_dir }}/validation_failure.out"
```

This renders as:

| Before | After |
|---|---|
| 🔴 "Validation Error" (red) | 🔵 "Action Required" (blue info) |

## Changes

- Added `parseOutputType()` helper function that detects `[INFO]` prefix
- Added `'info'` to the `validationMsg` type union (PatternFly Alert already supports `variant="info"`)
- `executeSolve()` now calls `parseOutputType()` instead of hardcoding `type: 'danger'`
- No changes to validation (`handleNext`) — validation errors always show as danger

## Use case

LB1390 module-03 solve: the GitHub VCS connection steps must be done manually by the attendee. The solve sets up AAP and then shows instructions for the GitHub steps. With this change, it shows as an informational blue dialog instead of a misleading red error.
