### PR TITLE
Fix iframe clipboard permissions by correcting feature policy syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "nookbag",
       "dependencies": {
         "@patternfly/react-core": "^6.3.1",
         "@patternfly/react-icons": "^6.3.1",
@@ -31,6 +30,7 @@
         "@types/react-dom": "^18.3.7",
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/ui": "^3.2.4",
+        "baseline-browser-mapping": "^2.10.19",
         "jsdom": "^27.0.0",
         "typescript": "^5.9.2",
         "vitest": "^3.2.4"
@@ -2340,12 +2340,15 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.25",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.25.tgz",
-      "integrity": "sha512-2NovHVesVF5TXefsGX1yzx1xgr7+m9JQenvz6FQY3qd+YXkKkYiv+vTCc7OriP9mcDZpTC5mAOYN4ocd29+erA==",
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bidi-js": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/react-dom": "^18.3.7",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
+    "baseline-browser-mapping": "^2.10.19",
     "jsdom": "^27.0.0",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -682,7 +682,7 @@ export default function () {
               width="100%"
               className="app__instructions"
               height="100%"
-              allow="clipboard-write clipboard-read"
+              allow="clipboard-write; clipboard-read"
               title={`Instructions - ${iframeModule}`}
               aria-label={`Instructions for ${iframeModule}`}
             ></iframe>
@@ -774,7 +774,7 @@ export default function () {
                           className="main-content"
                           title={`${tab.name} - primary`}
                           aria-label={`${tab.name} primary content`}
-                          allow="clipboard-write clipboard-read"
+                          allow="clipboard-write; clipboard-read"
                         ></iframe>
                       </div>
                       <div className="split bottom">
@@ -787,7 +787,7 @@ export default function () {
                           src={tab.secondary_url}
                           width="100%"
                           height="100%"
-                          allow="clipboard-write clipboard-read"
+                          allow="clipboard-write; clipboard-read"
                           style={{ display: 'block' }}
                           title={`${tab.secondary_name || 'Secondary'} - ${tab.name}`}
                           aria-label={`${tab.secondary_name || 'Secondary'} content for ${tab.name}`}
@@ -800,7 +800,7 @@ export default function () {
                       src={tab.url}
                       height="100%"
                       width="100%"
-                      allow="clipboard-write clipboard-read"
+                      allow="clipboard-write; clipboard-read"
                       style={{
                         ...(isTerminalTab(tab) ? { padding: '0 32px', background: '#000' } : {}),
                       }}


### PR DESCRIPTION
The `allow` attribute on iframes requires semicolons to separate feature policy directives, but all four iframe elements were using space-separated values. This caused clipboard-read/write permissions to silently fail in browsers that enforce the correct syntax.

## Changes
- Fix `allow` attribute on all four iframes in `app.tsx` to use semicolons (`clipboard-write; clipboard-read`) instead of spaces
- Add `baseline-browser-mapping` as an explicit dev dependency to resolve transitive dependency resolution warnings