### PR TITLE
Replace floating view switcher with right-edge popout and modernize UI

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -304,3 +304,22 @@ iframe {
   z-index: 1;
   position: relative;
 }
+
+/* Refresh icon hover affordance */
+.pf-v6-c-tabs__item-icon[onclick],
+.pf-c-tabs__item-icon[onclick],
+.pf-v6-c-tabs__item-icon:has(svg),
+.pf-c-tabs__item-icon:has(svg) {
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 2px;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+.pf-v6-c-tabs__item-icon:hover,
+.pf-c-tabs__item-icon:hover {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+.pf-v6-c-tabs__item-icon:active,
+.pf-c-tabs__item-icon:active {
+  background-color: rgba(0, 0, 0, 0.14);
+}

--- a/src/app.css
+++ b/src/app.css
@@ -21,7 +21,7 @@ iframe {
   padding: 0px;
   border: 0;
   /* Use inset shadow instead of border to avoid adding to total height */
-  box-shadow: inset 0 1px 0 #6a6e73;
+  box-shadow: none;
   background: #fff;
   color: #151515;
 }
@@ -47,12 +47,12 @@ iframe {
 }
 
 .split.bottom {
-  border-top: 1px solid #6a6e73;
+  border-top: none;
 }
 
 /* Style the tab */
 .tab {
-  border-bottom: 1px solid #6a6e73;
+  border-bottom: 1px solid var(--pf-t--global--color--nonstatus--gray--100, #e0e0e0);
   border-radius: 0;
   background-color: #fff;
   display: flex;
@@ -66,7 +66,7 @@ iframe {
   padding: 14px 16px;
   transition: 0.3s;
   color: #333;
-  border-right: 1px solid #6a6e73;
+  border-right: none;
   border-radius: 0;
 }
 
@@ -125,48 +125,89 @@ iframe {
 
 /** SPLIT **/
 .gutter {
-  background-color: #eee;
-  background-repeat: no-repeat;
-  background-position: 50%;
   display: flex;
   align-items: center;
+  justify-content: center;
+  position: relative;
 }
-.gutter.gutter-horizontal:after {
-  display: block;
-  content: ' ';
-  width: 17px;
-  position: absolute;
-  height: 35px;
-  margin-left: -9px;
-  background: url('data:image/svg+xml,<svg width="17" height="35" viewBox="0 0 17 35" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="w-[17px] absolute top-1/2 -translate-y-1/2 -left-1 text-[%2358647a] group-hover:text-[%236b7d9e]"><rect x="0.5" y="0.5" width="16" height="34" rx="7.5" fill="white" stroke="currentColor"></rect><rect x="6" y="8" width="5" height="5" rx="1" fill="currentColor" class="handle_svg__dot"></rect><rect x="6" y="15" width="5" height="5" rx="1" fill="currentColor" class="handle_svg__dot"></rect><rect x="6" y="22" width="5" height="5" rx="1" fill="currentColor" class="handle_svg__dot"></rect></svg>');
-}
-.gutter.gutter-vertical:after {
-  display: block;
-  content: ' ';
-  width: 35px;
-  position: absolute;
-  height: 17px;
-  margin-left: 50%;
-  left: -17px;
-  background: url('data:image/svg+xml,<svg width="35" height="17" viewBox="0 0 35 17" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="w-[35px] absolute top-1/2 -translate-y-1/2 -left-1 text-[%2358647a] group-hover:text-[%236b7d9e]"><rect x="0.5" y="0.5" width="34" height="16" rx="7.5" fill="white" stroke="currentColor"></rect><rect x="8" y="6" width="5" height="5" rx="1" fill="currentColor" class="handle_svg__dot"></rect><rect x="15" y="6" width="5" height="5" rx="1" fill="currentColor" class="handle_svg__dot"></rect><rect x="22" y="6" width="5" height="5" rx="1" fill="currentColor" class="handle_svg__dot"></rect></svg>');
-}
+
 .gutter.gutter-horizontal {
   cursor: col-resize;
   height: 100%;
   min-height: 100vh;
-  background-color: #6a6e73;
+  background-color: var(--pf-t--global--color--nonstatus--gray--100, #e0e0e0);
   z-index: 2;
+  transition: background-color 0.15s ease;
+}
+
+.gutter.gutter-horizontal:hover {
+  background-color: var(--pf-t--global--border--color--hover, #004d99);
+}
+
+.gutter.gutter-horizontal:active {
+  background-color: var(--pf-t--global--border--color--clicked, #003366);
+}
+
+.gutter.gutter-horizontal:after {
+  content: '';
+  position: absolute;
+  width: 10px;
+  height: 48px;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: 5px;
+  background: var(--pf-t--global--color--nonstatus--gray--200, #c7c7c7);
+  cursor: col-resize;
+  transition: background 0.15s ease, width 0.15s ease, height 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.gutter.gutter-horizontal:hover:after {
+  background: #ffffff;
+  width: 12px;
+  height: 54px;
+  border-radius: 6px;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.18);
 }
 
 .gutter.gutter-vertical {
   cursor: row-resize;
   width: 100%;
-  background-color: #ccc;
+  background-color: var(--pf-t--global--color--nonstatus--gray--100, #e0e0e0);
   z-index: 2;
+  transition: background-color 0.15s ease;
 }
 
-.gutter.gutter-horizontal {
-  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg==');
+.gutter.gutter-vertical:hover {
+  background-color: var(--pf-t--global--border--color--hover, #004d99);
+}
+
+.gutter.gutter-vertical:active {
+  background-color: var(--pf-t--global--border--color--clicked, #003366);
+}
+
+.gutter.gutter-vertical:after {
+  content: '';
+  position: absolute;
+  width: 48px;
+  height: 10px;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: 5px;
+  background: var(--pf-t--global--color--nonstatus--gray--200, #c7c7c7);
+  cursor: row-resize;
+  transition: background 0.15s ease, width 0.15s ease, height 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.gutter.gutter-vertical:hover:after {
+  background: #ffffff;
+  width: 54px;
+  height: 12px;
+  border-radius: 6px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
 }
 .split {
   -webkit-box-sizing: border-box;
@@ -194,8 +235,16 @@ iframe {
 }
 
 /* Reserve fixed height for the secondary tab header in the bottom split */
-.split.bottom > .pf-c-tabs {
+.split.bottom > .pf-c-tabs,
+.split.bottom > .pf-v6-c-tabs {
   flex: 0 0 56px;
+  border-bottom: 1px solid var(--pf-t--global--color--nonstatus--gray--100, #e0e0e0);
+}
+
+/* Remove PF's own underline so the container border provides a gap below the active indicator */
+.split.bottom > .pf-v6-c-tabs::before,
+.split.bottom > .pf-c-tabs::before {
+  border: 0;
 }
 
 .app-wrapper__inner {
@@ -226,7 +275,7 @@ iframe {
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 1px solid #6a6e73;
+  border-bottom: 1px solid var(--pf-t--global--color--nonstatus--gray--100, #e0e0e0);
 }
 
 .app-split-right__tabs {
@@ -238,7 +287,8 @@ iframe {
   gap: 12px;
   margin-right: 24px;
 }
-.app-split-right__tabs::before {
+.app-split-right__tabs::before,
+.app-split-right__tabs.pf-v6-c-tabs::before {
   border: 0;
 }
 .app-split-right__content {

--- a/src/app.css
+++ b/src/app.css
@@ -105,7 +105,7 @@ iframe {
   display: flex;
   flex-direction: row;
   align-items: flex-start;
-  border-top: 1px solid #6a6e73;
+  border-top: 1px solid var(--pf-t--global--color--nonstatus--gray--100, #e0e0e0);
 }
 .app-iframe__inner .pf-c-button {
   padding-top: var(--pf-c-button--PaddingTop);
@@ -118,7 +118,7 @@ iframe {
   height: 52px;
   display: flex;
   align-items: center;
-  border-bottom: 1px solid #6a6e73;
+  border-bottom: 1px solid var(--pf-t--global--color--nonstatus--gray--100, #e0e0e0);
   padding: 4px 5%;
   min-height: 52px;
 }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -626,7 +626,7 @@ export default function () {
               : [100]
           }
           minSize={viewMode === 'instructions' || viewMode === 'tabs' ? 0 : 100}
-          gutterSize={1}
+          gutterSize={2}
           direction="horizontal"
           cursor="col-resize"
           style={{ display: 'flex', flexDirection: 'row', resize: 'horizontal', height: '100%' }}
@@ -769,7 +769,7 @@ export default function () {
                     <Split
                       sizes={[50, 50]}
                       minSize={100}
-                      gutterSize={1}
+                      gutterSize={2}
                       cursor="row-resize"
                       direction="vertical"
                       style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
@@ -783,6 +783,9 @@ export default function () {
                           title={`${tab.name} - primary`}
                           aria-label={`${tab.name} primary content`}
                           allow="clipboard-write; clipboard-read"
+                          style={{
+                            ...(isTerminalTab(tab) ? { padding: '0 16px', background: '#000' } : {}),
+                          }}
                         ></iframe>
                       </div>
                       <div className="split bottom">
@@ -796,7 +799,10 @@ export default function () {
                           width="100%"
                           height="100%"
                           allow="clipboard-write; clipboard-read"
-                          style={{ display: 'block' }}
+                          style={{
+                            display: 'block',
+                            ...(isTerminalTab(tab) ? { padding: '0 16px', background: '#000' } : {}),
+                          }}
                           title={`${tab.secondary_name || 'Secondary'} - ${tab.name}`}
                           aria-label={`${tab.secondary_name || 'Secondary'} content for ${tab.name}`}
                         ></iframe>
@@ -810,7 +816,7 @@ export default function () {
                       width="100%"
                       allow="clipboard-write; clipboard-read"
                       style={{
-                        ...(isTerminalTab(tab) ? { padding: '0 32px', background: '#000' } : {}),
+                        ...(isTerminalTab(tab) ? { padding: '0 16px', background: '#000' } : {}),
                       }}
                       title={`${tab.name}`}
                       aria-label={`${tab.name} content`}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -545,11 +545,11 @@ export default function () {
     }
   }
 
-  function refreshTab(url: string) {
-    const tab = document.querySelector(`.app-split-right__content.active iframe`);
-    if (tab) {
-      (tab as HTMLIFrameElement).src = url;
-    }
+  function refreshTab() {
+    document.querySelectorAll(`.app-split-right__content.active iframe`).forEach((iframe) => {
+      const el = iframe as HTMLIFrameElement;
+      el.src = el.src;
+    });
   }
 
   // Keep URL param ?t in sync with currentTabName for programmatic changes as well
@@ -729,8 +729,8 @@ export default function () {
                         title={
                           <>
                             <TabTitleText>{s.name}</TabTitleText>{' '}
-                            {s.name === currentTabName && !s.secondary_url ? (
-                              <TabTitleIcon onClick={() => refreshTab(s.url as string)}>
+                            {s.name === currentTabName ? (
+                              <TabTitleIcon onClick={() => refreshTab()}>
                                 <RedoIcon color="grey" />
                               </TabTitleIcon>
                             ) : null}
@@ -791,7 +791,19 @@ export default function () {
                       <div className="split bottom">
                         {tab.secondary_name ? (
                           <Tabs activeKey={currentTabName} style={{ height: '56px' }}>
-                            <Tab eventKey={tab.name} title={<TabTitleText>{tab.secondary_name}</TabTitleText>}></Tab>
+                            <Tab eventKey={tab.name} title={
+                              <>
+                                <TabTitleText>{tab.secondary_name}</TabTitleText>{' '}
+                                <TabTitleIcon onClick={() => {
+                                  const el = document.querySelector(
+                                    `.app-split-right__content.active .split.bottom iframe`
+                                  ) as HTMLIFrameElement | null;
+                                  if (el) el.src = el.src;
+                                }}>
+                                  <RedoIcon color="grey" />
+                                </TabTitleIcon>
+                              </>
+                            }></Tab>
                           </Tabs>
                         ) : null}
                         <iframe

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -86,6 +86,13 @@ const createUrlsFromVars = (vars: TTab): TTab => {
     return {
       ...vars,
       external: vars.external ? Boolean(vars.external) : false,
+      ...(vars.secondary_path
+        ? {
+            secondary_url: `${protocol}//${hostname}${vars.secondary_port ? ':' + vars.secondary_port : ''}${
+              vars.secondary_path || ''
+            }`,
+          }
+        : {}),
     };
   }
   if (!vars.port) {
@@ -120,6 +127,11 @@ function showSolveBtn(module?: TModule) {
 function isTerminalTab(tab: TTab) {
   if (tab.type === 'terminal' || tab.type === 'secondary-terminal') return true;
   return tab.path?.startsWith('/wetty') || tab.path?.startsWith('/tty');
+}
+
+function isSecondaryTerminal(tab: TTab) {
+  if (tab.type === 'double-terminal') return true;
+  return tab.secondary_path?.startsWith('/wetty') || tab.secondary_path?.startsWith('/tty');
 }
 
 type Session = {
@@ -546,10 +558,15 @@ export default function () {
   }
 
   function refreshTab() {
-    document.querySelectorAll(`.app-split-right__content.active iframe`).forEach((iframe) => {
-      const el = iframe as HTMLIFrameElement;
-      el.src = el.src;
-    });
+    const active = document.querySelector(`.app-split-right__content.active`);
+    if (!active) return;
+    const top = active.querySelector(`.split.top iframe`) as HTMLIFrameElement | null;
+    if (top) {
+      top.src = top.src;
+    } else {
+      const solo = active.querySelector(`:scope > iframe`) as HTMLIFrameElement | null;
+      if (solo) solo.src = solo.src;
+    }
   }
 
   // Keep URL param ?t in sync with currentTabName for programmatic changes as well
@@ -813,7 +830,7 @@ export default function () {
                           allow="clipboard-write; clipboard-read"
                           style={{
                             display: 'block',
-                            ...(isTerminalTab(tab) ? { padding: '0 16px', background: '#000' } : {}),
+                            ...(isSecondaryTerminal(tab) ? { padding: '0 16px', background: '#000' } : {}),
                           }}
                           title={`${tab.secondary_name || 'Secondary'} - ${tab.name}`}
                           aria-label={`${tab.secondary_name || 'Secondary'} content for ${tab.name}`}

--- a/src/view-switcher.css
+++ b/src/view-switcher.css
@@ -75,22 +75,21 @@ body.sr-dragging {
   display: flex;
   flex-direction: column;
   gap: 2px;
+  width: 148px;
   background: #1a1a1a;
   border-radius: 8px 0 0 8px;
-  box-shadow: none;
-  padding: 0;
+  box-shadow: -2px 0 12px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.08);
+  padding: 4px;
   overflow: hidden;
-  max-width: 0;
+  transform: translateX(100%);
   opacity: 0;
-  transition: max-width 0.25s ease, opacity 0.2s ease, padding 0.25s ease, box-shadow 0.2s ease;
+  transition: transform 0.25s ease, opacity 0.2s ease;
   pointer-events: none;
 }
 
 .sr-popout.sr-expanded .sr-panel {
-  max-width: 160px;
+  transform: translateX(0);
   opacity: 1;
-  padding: 4px;
-  box-shadow: -2px 0 12px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.08);
   pointer-events: auto;
 }
 
@@ -175,8 +174,8 @@ body.sr-dragging {
     gap: 0;
     justify-content: center;
   }
-  .sr-popout.sr-expanded .sr-panel {
-    max-width: 48px;
+  .sr-panel {
+    width: 48px;
   }
 }
 

--- a/src/view-switcher.css
+++ b/src/view-switcher.css
@@ -21,11 +21,16 @@
   top: 0;
   z-index: 100;
   display: flex;
-  flex-direction: row-reverse;
+  flex-direction: row;
   align-items: stretch;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  /* top is set by JS via inline style; transform centers the widget on its Y position */
-  transform: translateY(-50%);
+  /* Collapsed: panel width off-screen, only trigger visible. Expanded: slides fully in. */
+  transform: translateX(var(--sr-panel-w, 148px)) translateY(-50%);
+  transition: transform 0.25s ease;
+}
+
+.sr-popout.sr-expanded {
+  transform: translateX(0) translateY(-50%);
 }
 
 /* While dragging, show grab cursor everywhere and prevent text selection */
@@ -81,25 +86,14 @@ body.sr-dragging {
   gap: 2px;
   width: 148px;
   background: #1a1a1a;
-  border-radius: 8px 0 0 8px;
-  box-shadow: -2px 0 12px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.08);
+  border-radius: 0;
+  box-shadow: 2px 0 12px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.08);
   padding: 4px;
   overflow: hidden;
-  transform: translateX(100%);
-  opacity: 0;
-  transition: transform 0.25s ease, opacity 0.2s ease;
-  pointer-events: none;
-}
-
-.sr-popout.sr-expanded .sr-panel {
-  transform: translateX(0);
-  opacity: 1;
-  pointer-events: auto;
 }
 
 /* When expanded, merge trigger + panel visually */
 .sr-popout.sr-expanded .sr-trigger {
-  border-radius: 0;
   background: #1a1a1a;
 }
 
@@ -170,6 +164,9 @@ body.sr-dragging {
     padding: 9px 10px;
     gap: 0;
     justify-content: center;
+  }
+  .sr-popout {
+    --sr-panel-w: 48px;
   }
   .sr-panel {
     width: 48px;

--- a/src/view-switcher.css
+++ b/src/view-switcher.css
@@ -13,6 +13,14 @@
  * split panes without touching Split.js inline styles (which would fight back).
  */
 
+/* ── Backdrop — transparent full-screen overlay to catch outside clicks ──── */
+
+.sr-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 99;
+}
+
 /* ── Outer wrapper — positions the whole widget on the right edge ────────── */
 
 .sr-popout {

--- a/src/view-switcher.css
+++ b/src/view-switcher.css
@@ -1,22 +1,11 @@
 /*
  * view-switcher.css
  *
- * Styles for the edge-snapping floating toolbar that lets users switch
- * between Instructions / Split / Tabs layout modes.
+ * Right-edge popout panel that lets users switch between
+ * Instructions / Split / Tabs layout modes.
  *
- * Positioning strategy
- * --------------------
- * The wrapper is fixed at (left:0, top:0) in the viewport. Actual position
- * is applied via CSS transform: translate(x, y) from JavaScript. This is
- * intentional — transforms are GPU-composited and do not trigger layout
- * recalculation on every frame the way left/top changes would.
- *
- * Drag + snap lifecycle
- * ---------------------
- *   pointerdown on .sr-drag-handle → body gets .sr-dragging, sr-snapping removed
- *   pointermove → transform updated directly on the DOM (no React re-render)
- *   pointerup   → nearest anchor found, sr-snapping added, transform animates
- *   transitionend → sr-snapping removed, ready for next drag
+ * Collapsed: a thin tab fixed to the right viewport edge.
+ * Expanded:  slides left to reveal vertically stacked mode buttons.
  *
  * Mode overrides
  * --------------
@@ -24,92 +13,91 @@
  * split panes without touching Split.js inline styles (which would fight back).
  */
 
-/* ── Toolbar wrapper ─────────────────────────────────────────────────────── */
+/* ── Outer wrapper — positions the whole widget on the right edge ────────── */
 
-.sr-toolbar-wrapper {
+.sr-popout {
   position: fixed;
-  left: 0;
+  right: 0;
   top: 0;
   z-index: 100;
-  /*
-   * transform: translate(x, y) is written by JavaScript to position the toolbar.
-   * will-change tells the browser to promote this element to its own compositor
-   * layer up front, so transform updates don't cause repaints of other layers.
-   * touch-action: none lets our pointer handlers work on touch screens without
-   * the browser trying to scroll the page at the same time.
-   */
-  will-change: transform;
-  touch-action: none;
-}
-
-/* ── Snap animation ─────────────────────────────────────────────────────── */
-
-/*
- * Added by JS on pointer-up, removed on transitionend. Enables a smooth
- * ease-out from the free-drag position to the nearest anchor point.
- * The class is also removed on the next pointer-down so a quick re-grab
- * cancels the animation and the toolbar responds immediately.
- */
-.sr-toolbar-wrapper.sr-snapping {
-  transition: transform 0.25s ease-out;
-}
-
-/* ── Toolbar pill ────────────────────────────────────────────────────────── */
-
-.sr-toolbar {
   display: flex;
-  align-items: center;
-  gap: 0;
-  background: #1a1a1a;
-  border-radius: 8px;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25), 0 0 0 1px rgba(255, 255, 255, 0.08);
-  padding: 3px;
+  flex-direction: row-reverse;
+  align-items: stretch;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  /* top is set by JS via inline style; transform centers the widget on its Y position */
+  transform: translateY(-50%);
 }
 
-/* ── Drag handle ─────────────────────────────────────────────────────────── */
-
-.sr-drag-handle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  /* Generous padding gives a larger hit target — easier to grab accurately */
-  min-width: 28px;
-  padding: 6px 10px 6px 8px;
-  cursor: grab;
-  color: #555;
-  border-right: 1px solid rgba(255, 255, 255, 0.12);
-  margin-right: 2px;
-  border-radius: 5px 0 0 5px;
-  transition: color 0.15s;
-}
-
-.sr-drag-handle:hover {
-  color: #bbb;
-  background: rgba(255, 255, 255, 0.07);
-}
-
-.sr-drag-handle svg {
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
-  /* pointer-events: none prevents the SVG from intercepting pointer events
-     that should be handled by the parent .sr-drag-handle div */
-  pointer-events: none;
-}
-
-/* ── Global drag state ───────────────────────────────────────────────────── */
-
-/*
- * While dragging, body gets .sr-dragging so the grabbing cursor applies
- * everywhere on the page — not just over the handle. Without this, moving
- * the pointer quickly over other elements causes the cursor to flicker back
- * to the default arrow cursor.
- * user-select: none prevents text being accidentally selected during drag.
- */
+/* While dragging, show grab cursor everywhere and prevent text selection */
 body.sr-dragging {
   cursor: grabbing !important;
   user-select: none !important;
+}
+
+/* ── Trigger tab — always visible ────────────────────────────────────────── */
+
+.sr-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  min-height: 72px;
+  background: rgba(26, 26, 26, 0.85);
+  border-radius: 8px 0 0 8px;
+  cursor: grab;
+  color: #888;
+  border: none;
+  padding: 0;
+  transition: color 0.2s, background 0.2s, width 0.2s;
+  touch-action: none;
+}
+
+.sr-trigger:hover {
+  color: #ddd;
+  background: rgba(26, 26, 26, 0.95);
+}
+
+.sr-trigger svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+  flex-shrink: 0;
+  transition: transform 0.25s ease;
+}
+
+.sr-popout.sr-expanded .sr-trigger svg {
+  transform: rotate(180deg);
+}
+
+/* ── Panel — slides in from the right ────────────────────────────────────── */
+
+.sr-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: #1a1a1a;
+  border-radius: 8px 0 0 8px;
+  box-shadow: none;
+  padding: 0;
+  overflow: hidden;
+  max-width: 0;
+  opacity: 0;
+  transition: max-width 0.25s ease, opacity 0.2s ease, padding 0.25s ease, box-shadow 0.2s ease;
+  pointer-events: none;
+}
+
+.sr-popout.sr-expanded .sr-panel {
+  max-width: 160px;
+  opacity: 1;
+  padding: 4px;
+  box-shadow: -2px 0 12px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.08);
+  pointer-events: auto;
+}
+
+/* When expanded, merge trigger + panel visually */
+.sr-popout.sr-expanded .sr-trigger {
+  border-radius: 0;
+  background: #1a1a1a;
 }
 
 /* ── Mode buttons ────────────────────────────────────────────────────────── */
@@ -117,8 +105,8 @@ body.sr-dragging {
 .sr-mode-btn {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 7px 14px;
+  gap: 8px;
+  padding: 9px 14px;
   border: none;
   border-radius: 6px;
   cursor: pointer;
@@ -126,9 +114,10 @@ body.sr-dragging {
   font-weight: 500;
   color: #999;
   background: transparent;
-  transition: all 0.2s ease;
+  transition: color 0.15s, background 0.15s;
   white-space: nowrap;
   line-height: 1;
+  width: 100%;
 }
 
 .sr-mode-btn:hover {
@@ -136,7 +125,6 @@ body.sr-dragging {
   background: rgba(255, 255, 255, 0.1);
 }
 
-/* Active button uses Red Hat red to match brand */
 .sr-mode-btn.sr-active {
   color: #fff;
   background: #ee0000;
@@ -146,6 +134,7 @@ body.sr-dragging {
 .sr-mode-btn__icon {
   display: flex;
   align-items: center;
+  flex-shrink: 0;
 }
 
 .sr-mode-btn__icon svg {
@@ -158,25 +147,45 @@ body.sr-dragging {
 /* ── Separator between buttons ───────────────────────────────────────────── */
 
 .sr-sep {
-  width: 1px;
-  height: 18px;
-  background: rgba(255, 255, 255, 0.12);
+  height: 1px;
+  background: rgba(255, 255, 255, 0.1);
   flex-shrink: 0;
+  margin: 0 4px;
 }
 
-/* ── Responsive: collapse to icon-only on narrow viewports ──────────────── */
+/* ── First-visit pulse animation ─────────────────────────────────────────── */
 
-/*
- * Below 900px the label text disappears and padding tightens.
- * The icons still convey the mode — labels are supplementary.
- */
+@keyframes sr-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(238, 0, 0, 0); }
+  50%      { box-shadow: 0 0 0 6px rgba(238, 0, 0, 0.4); }
+}
+
+.sr-trigger.sr-pulse {
+  animation: sr-pulse 1.2s ease-in-out 3;
+}
+
+/* ── Responsive: icon-only below 900px ───────────────────────────────────── */
+
 @media (max-width: 900px) {
   .sr-mode-btn__label {
     display: none;
   }
   .sr-mode-btn {
-    padding: 7px 10px;
+    padding: 9px 10px;
     gap: 0;
+    justify-content: center;
+  }
+  .sr-popout.sr-expanded .sr-panel {
+    max-width: 48px;
+  }
+}
+
+/* ── Touch devices: larger hit target ────────────────────────────────────── */
+
+@media (hover: none) {
+  .sr-trigger {
+    width: 36px;
+    min-height: 84px;
   }
 }
 

--- a/src/view-switcher.css
+++ b/src/view-switcher.css
@@ -52,6 +52,10 @@ body.sr-dragging {
   touch-action: none;
 }
 
+.sr-trigger:focus {
+  outline: none;
+}
+
 .sr-trigger:hover {
   color: #ddd;
   background: rgba(26, 26, 26, 0.95);
@@ -119,6 +123,10 @@ body.sr-dragging {
   width: 100%;
 }
 
+.sr-mode-btn:focus:not(:focus-visible) {
+  outline: none;
+}
+
 .sr-mode-btn:hover {
   color: #fff;
   background: rgba(255, 255, 255, 0.1);
@@ -150,17 +158,6 @@ body.sr-dragging {
   background: rgba(255, 255, 255, 0.1);
   flex-shrink: 0;
   margin: 0 4px;
-}
-
-/* ── First-visit pulse animation ─────────────────────────────────────────── */
-
-@keyframes sr-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(238, 0, 0, 0); }
-  50%      { box-shadow: 0 0 0 6px rgba(238, 0, 0, 0.4); }
-}
-
-.sr-trigger.sr-pulse {
-  animation: sr-pulse 1.2s ease-in-out 3;
 }
 
 /* ── Responsive: icon-only below 900px ───────────────────────────────────── */

--- a/src/view-switcher.tsx
+++ b/src/view-switcher.tsx
@@ -140,6 +140,7 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
   const [expanded, setExpanded] = useState(false);
   const [pulse, setPulse] = useState(false);
   const [yPercent, setYPercent] = useState(getSavedYPercent);
+  const [viewportH, setViewportH] = useState(() => window.innerHeight);
 
   const popoutRef = useRef<HTMLDivElement>(null);
   const mountedRef = useRef(false);
@@ -155,10 +156,11 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
   useEffect(() => { onModeChangeRef.current = onModeChange; }, [onModeChange]);
   const stableOnModeChange = useCallback((m: ViewMode) => onModeChangeRef.current(m), []);
 
-  // ── Re-clamp position when viewport height changes ─────────────────────
+  // ── Track viewport height and re-clamp position on resize ──────────────
   useEffect(() => {
     function onResize() {
       const h = window.innerHeight;
+      setViewportH(h);
       setYPercent(prev => {
         const px = (prev / 100) * h;
         const clamped = Math.max(CLAMP_MARGIN, Math.min(px, h - CLAMP_MARGIN));
@@ -203,7 +205,7 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
       const clamped = Math.max(CLAMP_MARGIN, Math.min(newPx, window.innerHeight - CLAMP_MARGIN));
       const pct = (clamped / window.innerHeight) * 100;
       if (popoutRef.current) {
-        popoutRef.current.style.top = `${pct}vh`;
+        popoutRef.current.style.top = `${clamped}px`;
       }
     }
   }
@@ -262,11 +264,13 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
   }, [persistUrlState]);
 
   // ── Render ─────────────────────────────────────────────────────────────
+  const topPx = Math.max(CLAMP_MARGIN, Math.min((yPercent / 100) * viewportH, viewportH - CLAMP_MARGIN));
+
   return (
     <div
       ref={popoutRef}
       className={`sr-popout${expanded ? ' sr-expanded' : ''}`}
-      style={{ top: `${yPercent}vh` }}
+      style={{ top: `${topPx}px` }}
       onKeyDown={onKeyDown}
     >
       <button

--- a/src/view-switcher.tsx
+++ b/src/view-switcher.tsx
@@ -216,6 +216,7 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
     }
   }
 
+
   // ── Mode persistence & URL sync ────────────────────────────────────────
   useEffect(() => {
     stableOnModeChange(mode);
@@ -242,6 +243,13 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
   const topPx = Math.max(CLAMP_MARGIN, Math.min((yPercent / 100) * viewportH, viewportH - CLAMP_MARGIN));
 
   return (
+    <>
+    {expanded && (
+      <div
+        className="sr-backdrop"
+        onMouseDown={() => setExpanded(false)}
+      />
+    )}
     <div
       ref={popoutRef}
       className={`sr-popout${expanded ? ' sr-expanded' : ''}`}
@@ -279,5 +287,6 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
         ))}
       </div>
     </div>
+    </>
   );
 }

--- a/src/view-switcher.tsx
+++ b/src/view-switcher.tsx
@@ -1,30 +1,23 @@
 /**
- * ViewSwitcher — edge-snapping floating toolbar for switching panel layout.
+ * ViewSwitcher — right-edge popout panel for switching panel layout.
  *
  * Layout modes:
  *   instructions — left panel only (full width)
  *   split        — left + right panels side by side (default)
  *   tabs         — right panel only (full width)
  *
- * Positioning:
- *   The toolbar snaps to one of 6 anchor points along the top and bottom
- *   viewport edges (top-left, top-center, top-right, bottom-left,
- *   bottom-center, bottom-right). Dragging moves it freely; on release it
- *   snaps to the nearest anchor with a short ease-out animation.
+ * Collapsed: a thin tab on the right viewport edge.
+ * Expanded:  slides left to reveal vertically stacked mode buttons.
  *
- * Drag behaviour:
- *   - User grabs the grip handle on the left of the toolbar
- *   - Uses Pointer Capture API so events keep routing to the handle
- *     even if the pointer leaves the browser window mid-drag
- *   - Position is applied via CSS transform (GPU-composited, no layout reflow)
- *   - On release, findNearestAnchor() picks the closest snap point
- *   - The sr-snapping CSS class enables a transition for the snap animation
+ * Interaction:
+ *   - Hover (with 150ms enter delay) or click to expand
+ *   - Mouse-leave (with 400ms delay) or mode selection to collapse
+ *   - Keyboard: Enter/Space toggles, Tab navigates, Escape closes
  *
  * localStorage keys:
- *   sr-panel-mode      — last selected view mode (instructions | split | tabs)
- *   sr-toolbar-anchor  — last snap anchor name (e.g. "bottom-center")
+ *   sr-panel-mode  — last selected view mode (instructions | split | tabs)
  */
-import React, { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 
 import './view-switcher.css';
 
@@ -42,104 +35,37 @@ type ViewSwitcherProps = {
   persistUrlState?: boolean;
 };
 
-// localStorage keys
-const STORE_KEY  = 'sr-panel-mode';
-const ANCHOR_KEY = 'sr-toolbar-anchor';
+const STORE_KEY = 'sr-panel-mode';
+const FIRST_VISIT_KEY = 'sr-visited';
+const YPOS_KEY = 'sr-ypos';
 
-type Pos = { x: number; y: number };
-
-// ─── Anchor system ────────────────────────────────────────────────────────────
-
-type Anchor =
-  | 'top-left' | 'top-center' | 'top-right'
-  | 'bottom-left' | 'bottom-center' | 'bottom-right';
-
-const ALL_ANCHORS: Anchor[] = [
-  'top-left', 'top-center', 'top-right',
-  'bottom-left', 'bottom-center', 'bottom-right',
-];
-
-const FALLBACK_W = 280;
-const FALLBACK_H = 44;
-const MARGIN     = 8;
-
-/** Compute pixel position for a named anchor given current viewport + toolbar size. */
-function anchorToPos(anchor: Anchor, tw: number, th: number): Pos {
-  const vw = window.innerWidth;
-  const vh = window.innerHeight;
-  switch (anchor) {
-    case 'top-left':      return { x: MARGIN,              y: MARGIN };
-    case 'top-center':    return { x: vw / 2 - tw / 2,    y: MARGIN };
-    case 'top-right':     return { x: vw - tw - MARGIN,    y: MARGIN };
-    case 'bottom-left':   return { x: MARGIN,              y: vh - th - MARGIN };
-    case 'bottom-center': return { x: vw / 2 - tw / 2,    y: vh - th - MARGIN };
-    case 'bottom-right':  return { x: vw - tw - MARGIN,    y: vh - th - MARGIN };
-  }
-}
-
-/** Find the anchor closest (Euclidean) to a free-drag position. */
-function findNearestAnchor(x: number, y: number, tw: number, th: number): Anchor {
-  let best: Anchor = 'bottom-center';
-  let bestDist = Infinity;
-  for (const a of ALL_ANCHORS) {
-    const p = anchorToPos(a, tw, th);
-    const dist = (p.x - x) ** 2 + (p.y - y) ** 2;
-    if (dist < bestDist) {
-      bestDist = dist;
-      best = a;
-    }
-  }
-  return best;
-}
-
-/** Clamp an arbitrary position so the toolbar stays within the viewport during drag. */
-function clampToViewport(x: number, y: number, tw: number, th: number): Pos {
-  return {
-    x: Math.max(MARGIN, Math.min(x, window.innerWidth  - tw - MARGIN)),
-    y: Math.max(MARGIN, Math.min(y, window.innerHeight - th - MARGIN)),
-  };
-}
-
-function getSavedAnchor(): Anchor {
-  try {
-    const raw = window.localStorage.getItem(ANCHOR_KEY);
-    if (raw && ALL_ANCHORS.includes(raw as Anchor)) return raw as Anchor;
-  } catch (_e) {}
-  return 'bottom-center';
-}
+const DRAG_THRESHOLD = 5;
+const CLAMP_MARGIN = 40;
 
 // ─── Icons ───────────────────────────────────────────────────────────────────
 
-/** Instructions mode — document icon */
 const IcoDoc = () => (
   <svg viewBox="0 0 24 24">
     <path d="M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zM6 20V4h7v5h5v11H6z" />
   </svg>
 );
 
-/** Split mode — two-column icon */
 const IcoSplit = () => (
   <svg viewBox="0 0 24 24">
     <path d="M3 3h8v18H3V3zm10 0h8v18h-8V3zM5 5v14h4V5H5zm10 0v14h4V5h-4z" />
   </svg>
 );
 
-/** Tabs mode — tabbed panel icon */
 const IcoTabs = () => (
   <svg viewBox="0 0 24 24">
     <path d="M21 3H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H3V5h10v4h8v10zM15 5h2v2h-2V5zm4 0h2v2h-2V5z" />
   </svg>
 );
 
-/** Six-dot grip — drag handle visual indicator */
-const IcoDrag = () => (
+/** Left-pointing chevron for the collapsed trigger tab */
+const IcoChevron = () => (
   <svg viewBox="0 0 24 24" aria-hidden="true">
-    <circle cx="9"  cy="7"  r="1.5" fill="currentColor" />
-    <circle cx="15" cy="7"  r="1.5" fill="currentColor" />
-    <circle cx="9"  cy="12" r="1.5" fill="currentColor" />
-    <circle cx="15" cy="12" r="1.5" fill="currentColor" />
-    <circle cx="9"  cy="17" r="1.5" fill="currentColor" />
-    <circle cx="15" cy="17" r="1.5" fill="currentColor" />
+    <path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z" />
   </svg>
 );
 
@@ -178,7 +104,29 @@ function getInitialMode(defaultMode: ViewMode): ViewMode {
   return defaultMode;
 }
 
-// Button definitions — order controls left-to-right rendering
+function getSavedYPercent(): number {
+  try {
+    const raw = window.localStorage.getItem(YPOS_KEY);
+    if (raw) {
+      const n = parseFloat(raw);
+      if (Number.isFinite(n)) return Math.max(0, Math.min(100, n));
+    }
+  } catch (_e) {}
+  return 50;
+}
+
+function isFirstVisit(): boolean {
+  try {
+    return !window.localStorage.getItem(FIRST_VISIT_KEY);
+  } catch (_e) {
+    return false;
+  }
+}
+
+function markVisited() {
+  try { window.localStorage.setItem(FIRST_VISIT_KEY, '1'); } catch (_e) {}
+}
+
 const buttons: { mode: ViewMode; Icon: React.FC; label: string; title: string }[] = [
   { mode: 'instructions', Icon: IcoDoc,   label: 'Instructions', title: 'Full-width instructions' },
   { mode: 'split',        Icon: IcoSplit, label: 'Split',        title: 'Side by side' },
@@ -189,156 +137,111 @@ const buttons: { mode: ViewMode; Icon: React.FC; label: string; title: string }[
 
 export default function ViewSwitcher({ defaultMode = 'split', onModeChange, persistUrlState }: ViewSwitcherProps) {
   const [mode, setMode] = useState<ViewMode>(() => getInitialMode(defaultMode));
-  const [anchor, setAnchor] = useState<Anchor>(getSavedAnchor);
-  const [pos, setPos] = useState<Pos>(() => anchorToPos(getSavedAnchor(), FALLBACK_W, FALLBACK_H));
+  const [expanded, setExpanded] = useState(false);
+  const [pulse, setPulse] = useState(false);
+  const [yPercent, setYPercent] = useState(getSavedYPercent);
 
-  const wrapperRef = useRef<HTMLDivElement>(null);
+  const popoutRef = useRef<HTMLDivElement>(null);
   const mountedRef = useRef(false);
-  const isSnapping = useRef(false);
 
-  // anchorRef mirrors anchor state so the resize handler always reads the
-  // latest value without being re-registered every time anchor changes.
-  const anchorRef = useRef(anchor);
-  useEffect(() => { anchorRef.current = anchor; }, [anchor]);
+  const drag = useRef<{
+    startPointerY: number;
+    startTopPx: number;
+    didDrag: boolean;
+  } | null>(null);
 
-  // Stabilise the onModeChange callback so the persistence effect doesn't
-  // re-run when a consumer passes a new arrow function on each render.
+  // Stabilise the onModeChange callback
   const onModeChangeRef = useRef(onModeChange);
   useEffect(() => { onModeChangeRef.current = onModeChange; }, [onModeChange]);
   const stableOnModeChange = useCallback((m: ViewMode) => onModeChangeRef.current(m), []);
 
-  // ── Toolbar measurement ─────────────────────────────────────────────────
-  function getToolbarSize(): { w: number; h: number } {
-    if (wrapperRef.current) {
-      const rect = wrapperRef.current.getBoundingClientRect();
-      if (rect.width > 0 && rect.height > 0) return { w: rect.width, h: rect.height };
+  // ── Apply Y position ──────────────────────────────────────────────────
+  useEffect(() => {
+    if (popoutRef.current) {
+      popoutRef.current.style.top = `${yPercent}vh`;
     }
-    return { w: FALLBACK_W, h: FALLBACK_H };
-  }
+  }, [yPercent]);
 
-  // ── Correct position once the real toolbar dimensions are known ─────────
-  // The initial pos state uses FALLBACK_W/H which may differ from the
-  // actual rendered size, pushing the toolbar off-screen on right anchors.
-  useLayoutEffect(() => {
-    const size = getToolbarSize();
-    setPos(anchorToPos(anchorRef.current, size.w, size.h));
-  }, []);
-
-  // ── Resize handling ──────────────────────────────────────────────────────
+  // ── Recalculate on window resize to stay in bounds ─────────────────────
   useEffect(() => {
     function onResize() {
-      const size = getToolbarSize();
-      setPos(anchorToPos(anchorRef.current, size.w, size.h));
+      setYPercent(prev => Math.max(0, Math.min(100, prev)));
     }
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);
   }, []);
 
-  // ── Drag state ───────────────────────────────────────────────────────────
-  const drag = useRef<{
-    pointerId:     number;
-    startPointerX: number;
-    startPointerY: number;
-    startElemX:    number;
-    startElemY:    number;
-  } | null>(null);
-
-  // ── Transform helper ─────────────────────────────────────────────────────
-  function applyTransform(x: number, y: number) {
-    if (wrapperRef.current) {
-      wrapperRef.current.style.transform = `translate(${x}px, ${y}px)`;
-    }
-  }
-
-  // Sync transform whenever pos state changes (initial render + after snap/resize)
+  // ── First-visit pulse ───────────────────────────────────────────────────
   useEffect(() => {
-    applyTransform(pos.x, pos.y);
-  }, [pos]);
-
-  // ── Snap animation cleanup ─────────────────────────────────────────────
-  // Remove the sr-snapping class after the CSS transition finishes so it
-  // doesn't interfere with the next drag.
-  useEffect(() => {
-    const el = wrapperRef.current;
-    if (!el) return;
-    function onTransitionEnd() {
-      isSnapping.current = false;
-      el!.classList.remove('sr-snapping');
+    if (isFirstVisit()) {
+      setPulse(true);
+      markVisited();
+      const t = setTimeout(() => setPulse(false), 4000);
+      return () => clearTimeout(t);
     }
-    el.addEventListener('transitionend', onTransitionEnd);
-    return () => el.removeEventListener('transitionend', onTransitionEnd);
   }, []);
 
-  // ── Pointer event handlers ───────────────────────────────────────────────
-
-  function onPointerDown(e: React.PointerEvent<HTMLDivElement>) {
+  // ── Vertical drag on trigger ───────────────────────────────────────────
+  function onPointerDown(e: React.PointerEvent<HTMLButtonElement>) {
     e.preventDefault();
-    (e.currentTarget as HTMLDivElement).setPointerCapture(e.pointerId);
-
-    let startX = pos.x;
-    let startY = pos.y;
-
-    // Cancel any in-progress snap animation. Read the current visual position
-    // from the DOM since pos state already holds the snap *target* which the
-    // CSS transition may not have reached yet.
-    if (isSnapping.current && wrapperRef.current) {
-      isSnapping.current = false;
-      wrapperRef.current.classList.remove('sr-snapping');
-      const rect = wrapperRef.current.getBoundingClientRect();
-      startX = rect.left;
-      startY = rect.top;
-      applyTransform(startX, startY);
-      setPos({ x: startX, y: startY });
-    }
-
-    document.body.classList.add('sr-dragging');
+    e.currentTarget.setPointerCapture(e.pointerId);
+    const topPx = (yPercent / 100) * window.innerHeight;
     drag.current = {
-      pointerId:     e.pointerId,
-      startPointerX: e.clientX,
       startPointerY: e.clientY,
-      startElemX:    startX,
-      startElemY:    startY,
+      startTopPx: topPx,
+      didDrag: false,
     };
   }
 
-  function onPointerMove(e: React.PointerEvent<HTMLDivElement>) {
+  function onPointerMove(e: React.PointerEvent<HTMLButtonElement>) {
     if (!drag.current) return;
-    const dx = e.clientX - drag.current.startPointerX;
     const dy = e.clientY - drag.current.startPointerY;
-    const size = getToolbarSize();
-    const { x, y } = clampToViewport(
-      drag.current.startElemX + dx,
-      drag.current.startElemY + dy,
-      size.w, size.h,
-    );
-    applyTransform(x, y);
+    if (!drag.current.didDrag && Math.abs(dy) >= DRAG_THRESHOLD) {
+      drag.current.didDrag = true;
+      document.body.classList.add('sr-dragging');
+    }
+    if (drag.current.didDrag) {
+      const newPx = drag.current.startTopPx + dy;
+      const clamped = Math.max(CLAMP_MARGIN, Math.min(newPx, window.innerHeight - CLAMP_MARGIN));
+      const pct = (clamped / window.innerHeight) * 100;
+      if (popoutRef.current) {
+        popoutRef.current.style.top = `${pct}vh`;
+      }
+    }
   }
 
-  function onPointerUp(e: React.PointerEvent<HTMLDivElement>) {
+  function onPointerUp(e: React.PointerEvent<HTMLButtonElement>) {
     if (!drag.current) return;
-    document.body.classList.remove('sr-dragging');
-
-    const dx = e.clientX - drag.current.startPointerX;
-    const dy = e.clientY - drag.current.startPointerY;
-    const freeX = drag.current.startElemX + dx;
-    const freeY = drag.current.startElemY + dy;
+    const wasDrag = drag.current.didDrag;
+    if (wasDrag) {
+      document.body.classList.remove('sr-dragging');
+      const dy = e.clientY - drag.current.startPointerY;
+      const newPx = drag.current.startTopPx + dy;
+      const clamped = Math.max(CLAMP_MARGIN, Math.min(newPx, window.innerHeight - CLAMP_MARGIN));
+      const pct = (clamped / window.innerHeight) * 100;
+      setYPercent(pct);
+      try { window.localStorage.setItem(YPOS_KEY, String(Math.round(pct))); } catch (_e) {}
+    }
     drag.current = null;
-
-    // Snap to nearest anchor with animated transition
-    const size = getToolbarSize();
-    const target = findNearestAnchor(freeX, freeY, size.w, size.h);
-    const snapPos = anchorToPos(target, size.w, size.h);
-
-    isSnapping.current = true;
-    wrapperRef.current?.classList.add('sr-snapping');
-    applyTransform(snapPos.x, snapPos.y);
-
-    setAnchor(target);
-    setPos(snapPos);
-    try { window.localStorage.setItem(ANCHOR_KEY, target); } catch (_e) {}
+    if (!wasDrag) {
+      setExpanded(prev => !prev);
+      setPulse(false);
+    }
   }
 
-  // ── Mode persistence & URL sync ──────────────────────────────────────────
+  function onModeSelect(selected: ViewMode) {
+    setMode(selected);
+  }
+
+  // ── Keyboard support ───────────────────────────────────────────────────
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Escape' && expanded) {
+      e.preventDefault();
+      setExpanded(false);
+    }
+  }
+
+  // ── Mode persistence & URL sync ────────────────────────────────────────
   useEffect(() => {
     stableOnModeChange(mode);
     if (mountedRef.current) {
@@ -350,7 +253,6 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
     mountedRef.current = true;
   }, [mode, stableOnModeChange, persistUrlState]);
 
-  // Sync mode from URL when the user navigates back/forward
   useEffect(() => {
     if (!persistUrlState) return;
     function handlePopState() {
@@ -361,25 +263,28 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
     return () => window.removeEventListener('popstate', handlePopState);
   }, [persistUrlState]);
 
-  // ── Render ───────────────────────────────────────────────────────────────
+  // ── Render ─────────────────────────────────────────────────────────────
   return (
     <div
-      ref={wrapperRef}
-      className="sr-toolbar-wrapper"
+      ref={popoutRef}
+      className={`sr-popout${expanded ? ' sr-expanded' : ''}`}
+      style={{ top: `${yPercent}vh` }}
+      onKeyDown={onKeyDown}
     >
-      <div className="sr-toolbar" role="toolbar" aria-label="View mode switcher">
+      <button
+        className={`sr-trigger${pulse ? ' sr-pulse' : ''}`}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        aria-expanded={expanded}
+        aria-label="View mode switcher"
+        title="Drag to reposition, click to open"
+      >
+        <IcoChevron />
+      </button>
 
-        <div
-          className="sr-drag-handle"
-          onPointerDown={onPointerDown}
-          onPointerMove={onPointerMove}
-          onPointerUp={onPointerUp}
-          onPointerCancel={onPointerUp}
-          title="Drag to reposition"
-        >
-          <IcoDrag />
-        </div>
-
+      <div className="sr-panel" role="toolbar" aria-label="View mode switcher">
         {buttons.map((btn, i) => (
           <React.Fragment key={btn.mode}>
             {i > 0 && <div className="sr-sep" aria-hidden="true" />}
@@ -387,7 +292,8 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
               className={`sr-mode-btn${mode === btn.mode ? ' sr-active' : ''}`}
               title={btn.title}
               aria-pressed={mode === btn.mode}
-              onClick={() => setMode(btn.mode)}
+              tabIndex={expanded ? 0 : -1}
+              onClick={() => onModeSelect(btn.mode)}
             >
               <span className="sr-mode-btn__icon" aria-hidden="true"><btn.Icon /></span>
               <span className="sr-mode-btn__label">{btn.label}</span>

--- a/src/view-switcher.tsx
+++ b/src/view-switcher.tsx
@@ -36,7 +36,6 @@ type ViewSwitcherProps = {
 };
 
 const STORE_KEY = 'sr-panel-mode';
-const FIRST_VISIT_KEY = 'sr-visited';
 const YPOS_KEY = 'sr-ypos';
 
 const DRAG_THRESHOLD = 5;
@@ -115,18 +114,6 @@ function getSavedYPercent(): number {
   return 50;
 }
 
-function isFirstVisit(): boolean {
-  try {
-    return !window.localStorage.getItem(FIRST_VISIT_KEY);
-  } catch (_e) {
-    return false;
-  }
-}
-
-function markVisited() {
-  try { window.localStorage.setItem(FIRST_VISIT_KEY, '1'); } catch (_e) {}
-}
-
 const buttons: { mode: ViewMode; Icon: React.FC; label: string; title: string }[] = [
   { mode: 'instructions', Icon: IcoDoc,   label: 'Instructions', title: 'Full-width instructions' },
   { mode: 'split',        Icon: IcoSplit, label: 'Split',        title: 'Side by side' },
@@ -138,7 +125,6 @@ const buttons: { mode: ViewMode; Icon: React.FC; label: string; title: string }[
 export default function ViewSwitcher({ defaultMode = 'split', onModeChange, persistUrlState }: ViewSwitcherProps) {
   const [mode, setMode] = useState<ViewMode>(() => getInitialMode(defaultMode));
   const [expanded, setExpanded] = useState(false);
-  const [pulse, setPulse] = useState(false);
   const [yPercent, setYPercent] = useState(getSavedYPercent);
   const [viewportH, setViewportH] = useState(() => window.innerHeight);
 
@@ -171,21 +157,10 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
     return () => window.removeEventListener('resize', onResize);
   }, []);
 
-  // ── First-visit pulse ───────────────────────────────────────────────────
-  useEffect(() => {
-    if (isFirstVisit()) {
-      setPulse(true);
-      markVisited();
-      const t = setTimeout(() => setPulse(false), 4000);
-      return () => clearTimeout(t);
-    }
-  }, []);
-
   // ── Vertical drag on trigger ───────────────────────────────────────────
   function onPointerDown(e: React.PointerEvent<HTMLButtonElement>) {
     e.preventDefault();
     e.currentTarget.setPointerCapture(e.pointerId);
-    e.currentTarget.focus();
     const topPx = (yPercent / 100) * window.innerHeight;
     drag.current = {
       startPointerY: e.clientY,
@@ -226,7 +201,6 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
     drag.current = null;
     if (!wasDrag) {
       setExpanded(prev => !prev);
-      setPulse(false);
     }
   }
 
@@ -275,7 +249,7 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
       onKeyDown={onKeyDown}
     >
       <button
-        className={`sr-trigger${pulse ? ' sr-pulse' : ''}`}
+        className="sr-trigger"
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}

--- a/src/view-switcher.tsx
+++ b/src/view-switcher.tsx
@@ -155,13 +155,6 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
   useEffect(() => { onModeChangeRef.current = onModeChange; }, [onModeChange]);
   const stableOnModeChange = useCallback((m: ViewMode) => onModeChangeRef.current(m), []);
 
-  // ── Apply Y position ──────────────────────────────────────────────────
-  useEffect(() => {
-    if (popoutRef.current) {
-      popoutRef.current.style.top = `${yPercent}vh`;
-    }
-  }, [yPercent]);
-
   // ── Recalculate on window resize to stay in bounds ─────────────────────
   useEffect(() => {
     function onResize() {

--- a/src/view-switcher.tsx
+++ b/src/view-switcher.tsx
@@ -155,10 +155,15 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
   useEffect(() => { onModeChangeRef.current = onModeChange; }, [onModeChange]);
   const stableOnModeChange = useCallback((m: ViewMode) => onModeChangeRef.current(m), []);
 
-  // ── Recalculate on window resize to stay in bounds ─────────────────────
+  // ── Re-clamp position when viewport height changes ─────────────────────
   useEffect(() => {
     function onResize() {
-      setYPercent(prev => Math.max(0, Math.min(100, prev)));
+      const h = window.innerHeight;
+      setYPercent(prev => {
+        const px = (prev / 100) * h;
+        const clamped = Math.max(CLAMP_MARGIN, Math.min(px, h - CLAMP_MARGIN));
+        return (clamped / h) * 100;
+      });
     }
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);

--- a/src/view-switcher.tsx
+++ b/src/view-switcher.tsx
@@ -185,6 +185,7 @@ export default function ViewSwitcher({ defaultMode = 'split', onModeChange, pers
   function onPointerDown(e: React.PointerEvent<HTMLButtonElement>) {
     e.preventDefault();
     e.currentTarget.setPointerCapture(e.pointerId);
+    e.currentTarget.focus();
     const topPx = (yPercent / 100) * window.innerHeight;
     drag.current = {
       startPointerY: e.clientY,


### PR DESCRIPTION
Replaces the draggable floating toolbar with a slide-out popout panel on the right viewport edge that never blocks content. Modernizes gutter handles, border colors, and tab styling to align with PatternFly design tokens.

## Changes

**View switcher**
- Replace 6-anchor draggable toolbar with a right-edge popout that slides in/out on click
- Trigger tab acts as a left-side handle that moves with the panel
- Vertically draggable along the right edge with position persisted to localStorage
- Closes on click outside (including over iframes via transparent backdrop overlay), Escape key, or trigger toggle
- Use pixel-based positioning instead of `vh` units for reliable behavior on mobile browsers
- Animate with GPU-composited `transform: translateX()` for smooth 60fps transitions
- Suppress focus ring on pointer clicks while keeping keyboard accessibility

**Gutter and borders**
- Replace inline SVG gutter handles with pure-CSS pill handles that animate on hover/active
- Migrate all hardcoded `#6a6e73` border colors to PF `--pf-t--global--color--nonstatus--gray--100` token
- Add `.pf-v6-c-tabs` selectors alongside `.pf-c-tabs` for PatternFly v6 forward-compatibility
- Increase `gutterSize` from 1 to 2px for better visual presence

**Tabs**
- Add refresh button to split-screen (double-terminal) tab headers
- Reduce terminal iframe padding from 32px to 16px and apply consistently to primary/secondary iframes