### PR TITLE
feat: remove solve buttons for event build

### DIFF
--- a/src/app.test.tsx
+++ b/src/app.test.tsx
@@ -374,7 +374,7 @@ describe('UI Config Integration Tests', () => {
       expect(window.open).toHaveBeenCalledWith('https://docs.example.com/lab-guide', '_blank');
     });
 
-    it('should handle lab progression and solve buttons', async () => {
+    it('should handle lab progression without solve buttons', async () => {
       mockUseSWR.mockImplementation((key) => {
         // First call: configuration files fetch (zero-touch config)
         if (Array.isArray(key) && key.includes('./ui-config.yml')) {
@@ -411,8 +411,8 @@ describe('UI Config Integration Tests', () => {
       );
 
       await waitFor(() => {
-        // Verify solve button is present for first module (lab-setup)
-        expect(screen.getByText('Solve')).toBeInTheDocument();
+        // Verify solve button is NOT present (removed for event build)
+        expect(screen.queryByText('Solve')).not.toBeInTheDocument();
       });
 
       // Test Next button functionality

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -110,13 +110,6 @@ function isScriptAvailable(module: TModule, scriptName: Step) {
   return module.scripts.includes(scriptName);
 }
 
-function showSolveBtn(module?: TModule) {
-  if (!module) return false;
-  if (module.solveButton === true) return true;
-  if (!module.scripts) return false;
-  return isScriptAvailable(module, 'solve');
-}
-
 function isTerminalTab(tab: TTab) {
   if (tab.type === 'terminal' || tab.type === 'secondary-terminal') return true;
   return tab.path?.startsWith('/wetty') || tab.path?.startsWith('/tty');
@@ -138,7 +131,7 @@ export default function () {
   const instructionsPanelRef = useRef(null);
   const [loaderStatus, setLoaderStatus] = useState<{
     isLoading: boolean;
-    stage: 'setup' | 'validation' | 'solve' | null;
+    stage: 'setup' | 'validation' | null;
   }>({ isLoading: false, stage: null });
   const searchParams = new URLSearchParams(document.location.search);
   const s = searchParams.get('s');
@@ -513,23 +506,7 @@ export default function () {
     }
   }
 
-  async function executeSolve() {
-    if (isScriptAvailable(modules[currIndex], 'solve')) {
-      setLoaderStatus({ isLoading: true, stage: 'solve' });
-      const executeStageAndGetStatusPromise = executeStageAndGetStatus(modules[currIndex].name, 'solve');
-      const minTimeout = new Promise((resolve) => setTimeout(() => resolve(null), 500));
-      const [res] = await Promise.all([executeStageAndGetStatusPromise, minTimeout]);
-      if (res.Status === 'successful') {
-        setLoaderStatus({ isLoading: false, stage: null });
-      } else {
-        setLoaderStatus({ isLoading: false, stage: null });
-        setValidationMsg({ message: res.Output || '', title: 'Validation Error', type: 'danger' });
-      }
-    }
-  }
-
   async function skipModule() {
-    await executeSolve();
     await handleNext();
   }
 
@@ -587,8 +564,6 @@ export default function () {
             ? 'Environment loading... almost ready!'
             : loaderStatus.stage === 'validation'
             ? 'Validating... standby.'
-            : loaderStatus.stage === 'solve'
-            ? 'Solving... standby.'
             : 'Loading...'
         }
         isVisible={loaderStatus.isLoading}
@@ -691,16 +666,6 @@ export default function () {
                 {currIndex > 0 ? (
                   <Button onClick={handlePrevious} className="lab-actions__previous">
                     Previous
-                  </Button>
-                ) : null}
-                {showSolveBtn(modules[currIndex]) ? (
-                  <Button
-                    style={{ marginLeft: 'auto' }}
-                    variant="secondary"
-                    className="lab-actions__solve"
-                    onClick={executeSolve}
-                  >
-                    Solve
                   </Button>
                 ) : null}
                 <Button style={{ marginLeft: 'auto' }} className="lab-actions__next" onClick={handleNext}>


### PR DESCRIPTION
Remove all solve button UI and functionality to prevent workshop users from triggering long-running solve scripts (some take 15+ minutes). Skip module now advances directly without running solve.